### PR TITLE
Forced to use standard button on checkout instead of Amazon pay

### DIFF
--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
@@ -15,3 +15,24 @@
         {{ block("page_checkout_confirm_address_shipping") }}
     </div>
 {% endblock %}
+
+
+{% block page_checkout_confirm_address_shipping_actions %}
+    <div class="card-actions">
+
+        {% set addressEditorOptions = {
+            changeShipping: true,
+            addressId: shippingAddress.id,
+            csrfToken: sw_csrf("frontend.account.addressbook", {"mode": "token"})
+        } %}
+
+        <a href="{{ path('frontend.account.address.edit.page', {'addressId': shippingAddress.id}) }}"
+           title="{{ "account.overviewChangeShipping"|trans|striptags }}"
+           class="btn btn-light"
+           data-address-editor="true"
+           data-address-editor-options='{{ addressEditorOptions|json_encode }}'>
+            {{ "account.overviewChangeShipping"|trans|sw_sanitize }}
+        </a>
+
+    </div>
+{% endblock %}


### PR DESCRIPTION
WARNING -merge only if we are sure that Amazon pay button for changing address should be overriden