### PR TITLE
Fixed endereco scanners - blocked infinite setInterval calls

### DIFF
--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -164,6 +164,9 @@
         window.EnderecoIntegrator.$formScanner = {
           loop: null,
           start: function() {
+            if (window.EnderecoIntegrator.formScannerStarted){
+                return;
+            }
             this.loop = setInterval( function() {
               document.querySelectorAll('[name="endereco_data_marker"][data-has-object="no"]').forEach( function(MarkerElement) {
                 var formElement = MarkerElement.closest('form');
@@ -284,6 +287,7 @@
                 MarkerElement.setAttribute('data-has-object', 'yes');
               });
             }, 1);
+            window.EnderecoIntegrator.formScannerStarted = true;
           },
           stop: function() {
 
@@ -294,12 +298,17 @@
     }
 
     function enderecoLoadAMSConfig() {
+      if (window.EnderecoIntegrator.configScannerStarted){
+          return;
+      }
+
       var $interval = setInterval( function() {
         if (!!window.EnderecoIntegrator.config) {
           enderecoSetConfigValues();
           clearInterval($interval);
         }
       }, 1);
+      window.EnderecoIntegrator.configScannerStarted = true;
     }
   </script>
   {% endif %}


### PR DESCRIPTION
Why this PR is needed?
I just checked that our endereco form scanner and config values interval are both called by other setInterval functions from endereco SDK. This was causing 'inception' bevahiour where one setInterval was setting up other setInterval in infinite loops which might slow down browser. Now form scanner and config setInterval's are setted up once and they are running correctly.

Code snippet which help me find out what's happening - add this to page head for testing
`<script type="application/javascript">
            const originalInterval = window.setInterval;
            console.log(originalInterval);
            window.setInterval = function (call, time){
                console.log('calling interval!!!!',call, time);
                originalInterval(call, time);
            }
        </script>`
This script is logging in console information about setting new interval in browser. In our case on enter on registration page it was calling new intervals infinitely
![image](https://user-images.githubusercontent.com/22631551/227877006-41b1e69b-3569-47ba-8d1a-cb8047b76d51.png)
