### PR TITLE
Try to avoid annotation problem

### DIFF
--- a/src/Controller/Api/ApiTestController.php
+++ b/src/Controller/Api/ApiTestController.php
@@ -11,7 +11,11 @@ use GuzzleHttp\Client;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 /**
- * @RouteScope(scopes={"administration"})
+ * This one is for SW Version < 6.4.11.0
+ * @RouteScope(scopes={"api"})
+ *
+ * This one is for SW Version >= 6.4.11.0
+ * @Route(defaults={"_routeScope"={"api"}})
  */
 class ApiTestController extends AbstractController
 {
@@ -23,23 +27,7 @@ class ApiTestController extends AbstractController
         $this->logger = $logger;
     }
 
-    /**
-     * @Route("/api/_action/endereco-shopware6-client/verify", name="api.api-test.check")
-     */
-    public function check(Request $request): JsonResponse
-    {
-        return $this->checkAPICredetials($request);
-    }
-
-    /**
-     * @Route("/api/v{version}/_action/endereco-shopware6-client/verify", name="api.api-test.checkOld")
-     */
-    public function checkOld(Request $request): JsonResponse
-    {
-        return $this->checkAPICredetials($request);
-    }
-
-    private function checkAPICredetials(Request $request): JsonResponse
+    public function checkAPICredentials(Request $request): JsonResponse
     {
         $apiKey = $request->get('EnderecoShopware6Client.config.enderecoApiKey');
         $endpointUrl = $request->get('EnderecoShopware6Client.config.enderecoRemoteUrl');

--- a/src/Resources/config/routes.php
+++ b/src/Resources/config/routes.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+$routes = new RouteCollection();
+
+$routes->add('api.api-test.check', new Route('/api/_action/endereco-shopware6-client/verify', [
+    '_controller' => 'Endereco\Shopware6Client\Controller\Api\ApiTestController::checkAPICredentials',
+    '_routeScope' => ['api'], // Custom attribute to represent the route scope
+]));
+
+return $routes;

--- a/src/Resources/config/routes.xml
+++ b/src/Resources/config/routes.xml
@@ -4,5 +4,5 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <import resource="../../Controller/Api/**/*Controller.php" type="annotation" />
+    <import resource="routes.php" />
 </routes>


### PR DESCRIPTION
Since 6.4.11.0 Shopware expects route scopes to be provided in "_routeScope" attribute.
The same goes for 6.5 (might be considered deprecated). Since 6.5 apparently only works with PHP 8.1 and  therefore assumes the usage of PHP Attributes instead of Annotations, I provide the routeScope Attribute vie PHP file that defines routes instead (otherwise it either works in older version or newer, but never both)