### PR TITLE
Implemented backward compatibility for sw_csrf function on SW6.5

### DIFF
--- a/src/Resources/views/storefront/misc/csrf-container.html.twig
+++ b/src/Resources/views/storefront/misc/csrf-container.html.twig
@@ -1,0 +1,2 @@
+{# Backward compatibility container for SW6.5.* - sw_csrf function cannot be rendered in 6.5.* #}
+{{ sw_csrf(action) }}

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
@@ -23,7 +23,11 @@
                   data-end-target-link-selector=".confirm-billing-address [data-address-editor]"
                   data-form-ajax-submit="true"
             >
-                {{ sw_csrf('frontend.endereco.account.address.edit.save') }}
+                {% if not feature('v6.5.0.0') %}
+                    {% sw_include '@EnderecoShopware6Client/storefront/misc/csrf-container.html.twig' with {
+                        'action': 'frontend.endereco.account.address.edit.save'
+                    } %}
+                {% endif %}
 
                 {% sw_include '@EnderecoShopware6Client/storefront/component/address/hidden-address-form.html.twig' with {
                     'prefix': 'billingAddress',
@@ -43,7 +47,11 @@
                   data-end-target-link-selector=".confirm-shipping-address [data-address-editor]"
                   data-form-ajax-submit="true"
             >
-                {{ sw_csrf('frontend.endereco.account.address.edit.save') }}
+                {% if not feature('v6.5.0.0') %}
+                    {% sw_include '@EnderecoShopware6Client/storefront/misc/csrf-container.html.twig' with {
+                        'action': 'frontend.endereco.account.address.edit.save'
+                    } %}
+                {% endif %}
 
                 {% sw_include '@EnderecoShopware6Client/storefront/component/address/hidden-address-form.html.twig' with {
                     'prefix': 'shippingAddress',


### PR DESCRIPTION
Why this is needed? Shopware in 6.5 version removes compeletely csrf tokens (sw_csrf) function. To make it backward compatible, sw_csrf function cannot be rendered in 6.5 instances