### PR TITLE
Add twig blocks around template extensions

### DIFF
--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -3,11 +3,13 @@
 {% block base_body_script %}
     {{ parent() }}
 
-    {% if page.endereco_config.pluginActive and (not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
-        <script
-                defer
-                async
-                src="{{ asset('bundles/enderecoshopware6client/endereco.min.js') }}?var={{ page.endereco_config.enderecoVersion }}"
-        ></script>
-    {% endif %}
+    {% block base_body_script_endereco_script %}
+        {% if page.endereco_config.pluginActive and (not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
+            <script
+                    defer
+                    async
+                    src="{{ asset('bundles/enderecoshopware6client/endereco.min.js') }}?var={{ page.endereco_config.enderecoVersion }}"
+            ></script>
+        {% endif %}
+    {% endblock %}
 {% endblock %}

--- a/src/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Resources/views/storefront/component/address/address-form.html.twig
@@ -2,93 +2,97 @@
 
 {% block component_address_form_address_fields %}
     {{ parent() }}
-    {% if page.endereco_config.pluginActive and ( not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
-        <input
-                type="hidden"
-                name="endereco_data_marker" value="ams"
-                data-container-selector = "form"
-                data-form-handle-ajax-submit = "true"
-                data-container-type = "form"
-                data-used-prefix = "{{ prefix }}"
-                data-has-object = "no"
-                data-name = ""
-                data-type = ""
-                data-country-code-selector = "{{ prefix }}[countryId]"
-                data-subdivision-code-selector = "{{ prefix }}[countryStateId]"
-                data-postal-code-selector = "{{ prefix }}[zipcode]"
-                data-locality-selector = "{{ prefix }}[city]"
-                data-street-full-selector = "{{ prefix }}[street]"
-                data-phone-selector = "{{ prefix }}[phoneNumber]"
-                data-street-selector = "{{ prefix }}[enderecoStreet]"
-                data-house-number-selector = "{{ prefix }}[enderecoHousenumber]"
-        >
-    {% endif %}
+    {% block component_address_form_address_fields_endereco_data_marker %}
+        {% if page.endereco_config.pluginActive and ( not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
+            <input
+                    type="hidden"
+                    name="endereco_data_marker" value="ams"
+                    data-container-selector = "form"
+                    data-form-handle-ajax-submit = "true"
+                    data-container-type = "form"
+                    data-used-prefix = "{{ prefix }}"
+                    data-has-object = "no"
+                    data-name = ""
+                    data-type = ""
+                    data-country-code-selector = "{{ prefix }}[countryId]"
+                    data-subdivision-code-selector = "{{ prefix }}[countryStateId]"
+                    data-postal-code-selector = "{{ prefix }}[zipcode]"
+                    data-locality-selector = "{{ prefix }}[city]"
+                    data-street-full-selector = "{{ prefix }}[street]"
+                    data-phone-selector = "{{ prefix }}[phoneNumber]"
+                    data-street-selector = "{{ prefix }}[enderecoStreet]"
+                    data-house-number-selector = "{{ prefix }}[enderecoHousenumber]"
+            >
+        {% endif %}
+    {% endblock %}
 {% endblock %}
 
 
  {% block component_address_form_street %}
-     {% if page.endereco_config.pluginActive and page.endereco_config.enderecoSplitStreet %}
-         <div class="form-group col-8 col-md-4">
-             {% if formViolations.getViolations("/enderecoStreet") is not empty %}
-                 {% set violationPath = "/enderecoStreet" %}
-             {% elseif formViolations.getViolations("/#{prefix}/enderecoStreet") is not empty %}
-                 {% set violationPath = "/#{prefix}/enderecoStreet" %}
-             {% endif %}
-
-             {% block component_address_form_endereco_street_label %}
-                 <label class="form-label"
-                        for="{{ prefix }}AddressStreet">
-                     {{ "enderecoshopware6client.inputFields.enderedoStreetLabel"|trans|sw_sanitize }}{{ "general.required"|trans|sw_sanitize }}
-                 </label>
-             {% endblock %}
-
-             {% block component_address_form_endereco_street_input %}
-                 <input type="text"
-                        class="form-control{% if violationPath %} is-invalid{% endif %}"
-                        id="{{ prefix }}AddressStreet"
-                        placeholder="{{ "enderecoshopware6client.inputFields.enderedoStreetPlaceholder"|trans|striptags }}"
-                        name="{{ prefix }}[enderecoStreet]"
-                        value="{{ data.get('extensions')['enderecoAddress'].street }}"
-                        required="required">
-             {% endblock %}
-
-             {% block component_address_form_endereco_street_input_error %}
-                 {% if violationPath %}
-                     {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' %}
+     {% block component_address_form_street_endereco_street_splitter %}
+         {% if page.endereco_config.pluginActive and page.endereco_config.enderecoSplitStreet %}
+             <div class="form-group col-8 col-md-4">
+                 {% if formViolations.getViolations("/enderecoStreet") is not empty %}
+                     {% set violationPath = "/enderecoStreet" %}
+                 {% elseif formViolations.getViolations("/#{prefix}/enderecoStreet") is not empty %}
+                     {% set violationPath = "/#{prefix}/enderecoStreet" %}
                  {% endif %}
-             {% endblock %}
-         </div>
-         <div class="form-group col-4 col-md-2">
-             {% if formViolations.getViolations("/enderecoHousenumber") is not empty %}
-                 {% set violationPath = "/enderecoHousenumber" %}
-             {% elseif formViolations.getViolations("/#{prefix}/enderecoHousenumber") is not empty %}
-                 {% set violationPath = "/#{prefix}/enderecoHousenumber" %}
-             {% endif %}
 
-             {% block component_address_form_endereco_housenumber_label %}
-                 <label class="form-label"
-                        for="{{ prefix }}AddressStreet">
-                     {{ "enderecoshopware6client.inputFields.enderedoHousenumberLabel"|trans|sw_sanitize }}{{ "general.required"|trans|sw_sanitize }}
-                 </label>
-             {% endblock %}
+                 {% block component_address_form_endereco_street_label %}
+                     <label class="form-label"
+                            for="{{ prefix }}AddressStreet">
+                         {{ "enderecoshopware6client.inputFields.enderedoStreetLabel"|trans|sw_sanitize }}{{ "general.required"|trans|sw_sanitize }}
+                     </label>
+                 {% endblock %}
 
-             {% block component_address_form_endereco_housenumber_input %}
-                 <input type="text"
-                        class="form-control{% if violationPath %} is-invalid{% endif %}"
-                        id="{{ prefix }}AddressHouseNumber"
-                        placeholder="{{ "enderecoshopware6client.inputFields.enderedoHousenumberPlaceholder"|trans|striptags }}"
-                        name="{{ prefix }}[enderecoHousenumber]"
-                        value="{{ data.get('extensions')['enderecoAddress'].houseNumber }}"
-                        required="required">
-             {% endblock %}
+                 {% block component_address_form_endereco_street_input %}
+                     <input type="text"
+                            class="form-control{% if violationPath %} is-invalid{% endif %}"
+                            id="{{ prefix }}AddressStreet"
+                            placeholder="{{ "enderecoshopware6client.inputFields.enderedoStreetPlaceholder"|trans|striptags }}"
+                            name="{{ prefix }}[enderecoStreet]"
+                            value="{{ data.get('extensions')['enderecoAddress'].street }}"
+                            required="required">
+                 {% endblock %}
 
-             {% block component_address_form_endereco_housenumber_input_error %}
-                 {% if violationPath %}
-                     {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' %}
+                 {% block component_address_form_endereco_street_input_error %}
+                     {% if violationPath %}
+                         {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' %}
+                     {% endif %}
+                 {% endblock %}
+             </div>
+             <div class="form-group col-4 col-md-2">
+                 {% if formViolations.getViolations("/enderecoHousenumber") is not empty %}
+                     {% set violationPath = "/enderecoHousenumber" %}
+                 {% elseif formViolations.getViolations("/#{prefix}/enderecoHousenumber") is not empty %}
+                     {% set violationPath = "/#{prefix}/enderecoHousenumber" %}
                  {% endif %}
-             {% endblock %}
-         </div>
-     {% else %}
-         {{ parent() }}
-     {% endif %}
+
+                 {% block component_address_form_endereco_housenumber_label %}
+                     <label class="form-label"
+                            for="{{ prefix }}AddressStreet">
+                         {{ "enderecoshopware6client.inputFields.enderedoHousenumberLabel"|trans|sw_sanitize }}{{ "general.required"|trans|sw_sanitize }}
+                     </label>
+                 {% endblock %}
+
+                 {% block component_address_form_endereco_housenumber_input %}
+                     <input type="text"
+                            class="form-control{% if violationPath %} is-invalid{% endif %}"
+                            id="{{ prefix }}AddressHouseNumber"
+                            placeholder="{{ "enderecoshopware6client.inputFields.enderedoHousenumberPlaceholder"|trans|striptags }}"
+                            name="{{ prefix }}[enderecoHousenumber]"
+                            value="{{ data.get('extensions')['enderecoAddress'].houseNumber }}"
+                            required="required">
+                 {% endblock %}
+
+                 {% block component_address_form_endereco_housenumber_input_error %}
+                     {% if violationPath %}
+                         {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' %}
+                     {% endif %}
+                 {% endblock %}
+             </div>
+         {% else %}
+             {{ parent() }}
+         {% endif %}
+     {% endblock%}
  {% endblock %}

--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -1,219 +1,220 @@
 {% sw_extends '@Storefront/storefront/layout/meta.html.twig' %}
 
 {% block layout_head_meta_tags %}
-  {% if page.endereco_config.pluginActive and ( not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
-  <script>
-    if (undefined === window.EnderecoIntegrator) {
-      window.EnderecoIntegrator = {};
-    }
-    if (!window.EnderecoIntegrator.onLoad) {
-      window.EnderecoIntegrator.onLoad = [];
-    }
-
-    window.EnderecoIntegrator.countryCodeToNameMapping = JSON.parse('{{ page.endereco_config.countryCodeToNameMapping|raw }}');
-    window.EnderecoIntegrator.countryMapping = JSON.parse('{{ page.endereco_config.countryMapping|raw }}');
-    window.EnderecoIntegrator.countryMappingReverse = JSON.parse('{{ page.endereco_config.countryMappingReverse|raw }}');
-
-    window.EnderecoIntegrator.subdivisionCodeToNameMapping = JSON.parse('{{ page.endereco_config.subdivisionCodeToNameMapping|raw }}');
-    window.EnderecoIntegrator.subdivisionMapping = JSON.parse('{{ page.endereco_config.subdivisionMapping|raw }}');
-    window.EnderecoIntegrator.subdivisionMappingReverse = JSON.parse('{{ page.endereco_config.subdivisionMappingReverse|raw }}');
-
-    function enderecoInitAMS(prefix, config, cb) {
-      if (undefined !== window.EnderecoIntegrator.initAMS) {
-        var EAO = window.EnderecoIntegrator.initAMS(prefix, config);
-        if (cb) {
-          cb(EAO);
+  {% block layout_head_meta_tags_endereco_script %}
+    {% if page.endereco_config.pluginActive and ( not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
+      <script>
+        if (undefined === window.EnderecoIntegrator) {
+          window.EnderecoIntegrator = {};
         }
-      } else {
-        window.EnderecoIntegrator.onLoad.push(function () {
-          var EAO = window.EnderecoIntegrator.initAMS(prefix, config);
-          if (cb) {
-            cb(EAO);
+        if (!window.EnderecoIntegrator.onLoad) {
+          window.EnderecoIntegrator.onLoad = [];
+        }
+
+        window.EnderecoIntegrator.countryCodeToNameMapping = JSON.parse('{{ page.endereco_config.countryCodeToNameMapping|raw }}');
+        window.EnderecoIntegrator.countryMapping = JSON.parse('{{ page.endereco_config.countryMapping|raw }}');
+        window.EnderecoIntegrator.countryMappingReverse = JSON.parse('{{ page.endereco_config.countryMappingReverse|raw }}');
+
+        window.EnderecoIntegrator.subdivisionCodeToNameMapping = JSON.parse('{{ page.endereco_config.subdivisionCodeToNameMapping|raw }}');
+        window.EnderecoIntegrator.subdivisionMapping = JSON.parse('{{ page.endereco_config.subdivisionMapping|raw }}');
+        window.EnderecoIntegrator.subdivisionMappingReverse = JSON.parse('{{ page.endereco_config.subdivisionMappingReverse|raw }}');
+
+        function enderecoInitAMS(prefix, config, cb) {
+          if (undefined !== window.EnderecoIntegrator.initAMS) {
+            var EAO = window.EnderecoIntegrator.initAMS(prefix, config);
+            if (cb) {
+              cb(EAO);
+            }
+          } else {
+            window.EnderecoIntegrator.onLoad.push(function () {
+              var EAO = window.EnderecoIntegrator.initAMS(prefix, config);
+              if (cb) {
+                cb(EAO);
+              }
+            });
           }
-        });
-      }
-    }
+        }
 
-    function enderecoInitES(prefix, config) {
-      if (undefined !== window.EnderecoIntegrator.initEmailServices) {
-        window.EnderecoIntegrator.initEmailServices(prefix, config);
-      } else {
-        window.EnderecoIntegrator.onLoad.push(function () {
-          window.EnderecoIntegrator.initEmailServices(prefix, config);
-        });
-      }
-    }
+        function enderecoInitES(prefix, config) {
+          if (undefined !== window.EnderecoIntegrator.initEmailServices) {
+            window.EnderecoIntegrator.initEmailServices(prefix, config);
+          } else {
+            window.EnderecoIntegrator.onLoad.push(function () {
+              window.EnderecoIntegrator.initEmailServices(prefix, config);
+            });
+          }
+        }
 
-    function enderecoInitPS(prefix, config) {
-      if (undefined !== window.EnderecoIntegrator.initEmailServices) {
-        window.EnderecoIntegrator.initPersonServices(prefix, config);
-      } else {
-        window.EnderecoIntegrator.onLoad.push(function () {
-          window.EnderecoIntegrator.initPersonServices(prefix, config);
-        });
-      }
-    }
+        function enderecoInitPS(prefix, config) {
+          if (undefined !== window.EnderecoIntegrator.initEmailServices) {
+            window.EnderecoIntegrator.initPersonServices(prefix, config);
+          } else {
+            window.EnderecoIntegrator.onLoad.push(function () {
+              window.EnderecoIntegrator.initPersonServices(prefix, config);
+            });
+          }
+        }
 
-    function enderecoSetConfigValues() {
-      window.EnderecoIntegrator.themeName = '';
-      window.EnderecoIntegrator.defaultCountrySelect = !!('{{ page.endereco_config.defaultCountrySelect }}');
-      window.EnderecoIntegrator.defaultCountry = '{{ page.endereco_config.defaultCountry }}';
-      window.EnderecoIntegrator.config.agentName = '{{ page.endereco_config.enderecoAgentInfo }}';
+        function enderecoSetConfigValues() {
+          window.EnderecoIntegrator.themeName = '';
+          window.EnderecoIntegrator.defaultCountrySelect = !!('{{ page.endereco_config.defaultCountrySelect }}');
+          window.EnderecoIntegrator.defaultCountry = '{{ page.endereco_config.defaultCountry }}';
+          window.EnderecoIntegrator.config.agentName = '{{ page.endereco_config.enderecoAgentInfo }}';
 
-      if ('{{ page.endereco_config.pathToIoPhp }}' !== '') {
-        window.EnderecoIntegrator.config.apiUrl = '{{ page.endereco_config.pathToIoPhp }}';
-      } else  {
-        window.EnderecoIntegrator.config.apiUrl = '{{ asset('bundles/enderecoshopware6client/io.php') }}';
-      }
+          if ('{{ page.endereco_config.pathToIoPhp }}' !== '') {
+            window.EnderecoIntegrator.config.apiUrl = '{{ page.endereco_config.pathToIoPhp }}';
+          } else  {
+            window.EnderecoIntegrator.config.apiUrl = '{{ asset('bundles/enderecoshopware6client/io.php') }}';
+          }
 
-      window.EnderecoIntegrator.config.apiKey = '{{ page.endereco_config.enderecoApiKey }}';
-      window.EnderecoIntegrator.config.showDebugInfo = false;
-      window.EnderecoIntegrator.config.remoteApiUrl = '{{ page.endereco_config.enderecoRemoteUrl }}';
-      window.EnderecoIntegrator.config.trigger.onblur = !!('{{ page.endereco_config.enderecoTriggerOnBlur }}');
-      window.EnderecoIntegrator.config.trigger.onsubmit = !!('{{ page.endereco_config.enderecoTriggerOnSubmit }}');
-      window.EnderecoIntegrator.config.ux.smartFill = false;
-      window.EnderecoIntegrator.config.ux.checkExisting = false;
-      window.EnderecoIntegrator.config.ux.resumeSubmit = !!('{{ page.endereco_config.enderecoContinueSubmit }}');
-      window.EnderecoIntegrator.config.ux.useStandardCss = true;
-      window.EnderecoIntegrator.config.ux.showEmailStatus = false;
-      window.EnderecoIntegrator.config.ux.allowCloseModal = !!('{{ page.endereco_config.enderecoAllowCloseIcon }}');
-      window.EnderecoIntegrator.config.ux.confirmWithCheckbox = !!('{{ page.endereco_config.enderecoConfirmWithCheckbox }}');
-      window.EnderecoIntegrator.config.ux.changeFieldsOrder = true;
-      window.EnderecoIntegrator.config.ux.showPhoneErrors = {{ page.endereco_config.enderecoShowPhoneErrors ? 'true':'false' }};
-      window.EnderecoIntegrator.config.ux.showPhoneFlag = true;
-      window.EnderecoIntegrator.config.phoneFormat = '{{ page.endereco_config.enderecoPhsUseFormat }}';
-      window.EnderecoIntegrator.config.defaultPhoneType = '{{ page.endereco_config.enderecoPhsDefaultFieldType }}';
-      window.EnderecoIntegrator.config.splitStreet = {{ page.endereco_config.enderecoSplitStreet ? 'true':'false' }};
-      window.EnderecoIntegrator.countryMappingUrl = '';
-      window.EnderecoIntegrator.config.templates.primaryButtonClasses = 'btn btn-primary btn-lg';
-      window.EnderecoIntegrator.config.templates.secondaryButtonClasses = 'btn btn-secondary btn-lg';
-      window.EnderecoIntegrator.config.texts = {
-        popUpHeadline: '{{ "enderecoshopware6client.texts.popUpHeadline"|trans|sw_sanitize|escape }}',
-        popUpSubline: '{{ "enderecoshopware6client.texts.popUpSubline"|trans|sw_sanitize|escape }}',
-        mistakeNoPredictionSubline: '{{ "enderecoshopware6client.texts.mistakeNoPredictionSubline"|trans|sw_sanitize|escape }}',
-        confirmMyAddressCheckbox: '{{ "enderecoshopware6client.texts.confirmMyAddressCheckbox"|trans|sw_sanitize|escape }}',
-        notFoundSubline: '{{ "enderecoshopware6client.texts.notFoundSubline"|trans|sw_sanitize|escape }}',
-        yourInput: '{{ "enderecoshopware6client.texts.yourInput"|trans|sw_sanitize|escape }}',
-        editYourInput: '{{ "enderecoshopware6client.texts.editYourInput"|trans|sw_sanitize|escape }}',
-        ourSuggestions: '{{ "enderecoshopware6client.texts.ourSuggestions"|trans|sw_sanitize|escape }}',
-        useSelected: '{{ "enderecoshopware6client.texts.useSelected"|trans|sw_sanitize|escape }}',
-        confirmAddress: '{{ "enderecoshopware6client.texts.confirmAddress"|trans|sw_sanitize|escape }}',
-        editAddress: '{{ "enderecoshopware6client.texts.editAddress"|trans|sw_sanitize|escape }}',
-        warningText: '{{ "enderecoshopware6client.texts.warningText"|trans|sw_sanitize|escape }}',
-        popupHeadlines: {
-          general_address: '{{ "enderecoshopware6client.texts.general_address"|trans|sw_sanitize|escape }}',
-          billing_address: '{{ "enderecoshopware6client.texts.billing_address"|trans|sw_sanitize|escape }}',
-          shipping_address: '{{ "enderecoshopware6client.texts.shipping_address"|trans|sw_sanitize|escape }}',
-        },
-        statuses: {
-          email_not_correct: '{{ "enderecoshopware6client.statuses.email_not_correct"|trans|sw_sanitize|escape }}',
-          email_cant_receive: '{{ "enderecoshopware6client.statuses.email_cant_receive"|trans|sw_sanitize|escape }}',
-          email_syntax_error: '{{ "enderecoshopware6client.statuses.email_syntax_error"|trans|sw_sanitize|escape }}',
-          email_no_mx: '{{ "enderecoshopware6client.statuses.email_no_mx"|trans|sw_sanitize|escape }}',
-          building_number_is_missing: '{{ "enderecoshopware6client.statuses.building_number_is_missing"|trans|sw_sanitize|escape }}',
-          building_number_not_found: '{{ "enderecoshopware6client.statuses.building_number_not_found"|trans|sw_sanitize|escape }}',
-          street_name_needs_correction: '{{ "enderecoshopware6client.statuses.street_name_needs_correction"|trans|sw_sanitize|escape }}',
-          locality_needs_correction: '{{ "enderecoshopware6client.statuses.locality_needs_correction"|trans|sw_sanitize|escape }}',
-          postal_code_needs_correction: '{{ "enderecoshopware6client.statuses.postal_code_needs_correction"|trans|sw_sanitize|escape }}',
-          country_code_needs_correction: '{{ "enderecoshopware6client.statuses.country_code_needs_correction"|trans|sw_sanitize|escape }}',
-            phone_invalid: '{{ "enderecoshopware6client.statuses.phone_invalid"|trans|sw_sanitize|escape }}',
-            phone_format_needs_correction: '{{ "enderecoshopware6client.statuses.phone_format_needs_correction"|trans|sw_sanitize|escape }}',
-            phone_should_be_fixed: '{{ "enderecoshopware6client.statuses.phone_should_be_fixed"|trans|sw_sanitize|escape }}',
-            phone_should_be_mobile: '{{ "enderecoshopware6client.statuses.phone_should_be_mobile"|trans|sw_sanitize|escape }}',
-        },
-          requiredFormat: {
+          window.EnderecoIntegrator.config.apiKey = '{{ page.endereco_config.enderecoApiKey }}';
+          window.EnderecoIntegrator.config.showDebugInfo = false;
+          window.EnderecoIntegrator.config.remoteApiUrl = '{{ page.endereco_config.enderecoRemoteUrl }}';
+          window.EnderecoIntegrator.config.trigger.onblur = !!('{{ page.endereco_config.enderecoTriggerOnBlur }}');
+          window.EnderecoIntegrator.config.trigger.onsubmit = !!('{{ page.endereco_config.enderecoTriggerOnSubmit }}');
+          window.EnderecoIntegrator.config.ux.smartFill = false;
+          window.EnderecoIntegrator.config.ux.checkExisting = false;
+          window.EnderecoIntegrator.config.ux.resumeSubmit = !!('{{ page.endereco_config.enderecoContinueSubmit }}');
+          window.EnderecoIntegrator.config.ux.useStandardCss = true;
+          window.EnderecoIntegrator.config.ux.showEmailStatus = false;
+          window.EnderecoIntegrator.config.ux.allowCloseModal = !!('{{ page.endereco_config.enderecoAllowCloseIcon }}');
+          window.EnderecoIntegrator.config.ux.confirmWithCheckbox = !!('{{ page.endereco_config.enderecoConfirmWithCheckbox }}');
+          window.EnderecoIntegrator.config.ux.changeFieldsOrder = true;
+          window.EnderecoIntegrator.config.ux.showPhoneErrors = {{ page.endereco_config.enderecoShowPhoneErrors ? 'true':'false' }};
+          window.EnderecoIntegrator.config.ux.showPhoneFlag = true;
+          window.EnderecoIntegrator.config.phoneFormat = '{{ page.endereco_config.enderecoPhsUseFormat }}';
+          window.EnderecoIntegrator.config.defaultPhoneType = '{{ page.endereco_config.enderecoPhsDefaultFieldType }}';
+          window.EnderecoIntegrator.config.splitStreet = {{ page.endereco_config.enderecoSplitStreet ? 'true':'false' }};
+          window.EnderecoIntegrator.countryMappingUrl = '';
+          window.EnderecoIntegrator.config.templates.primaryButtonClasses = 'btn btn-primary btn-lg';
+          window.EnderecoIntegrator.config.templates.secondaryButtonClasses = 'btn btn-secondary btn-lg';
+          window.EnderecoIntegrator.config.texts = {
+            popUpHeadline: '{{ "enderecoshopware6client.texts.popUpHeadline"|trans|sw_sanitize|escape }}',
+            popUpSubline: '{{ "enderecoshopware6client.texts.popUpSubline"|trans|sw_sanitize|escape }}',
+            mistakeNoPredictionSubline: '{{ "enderecoshopware6client.texts.mistakeNoPredictionSubline"|trans|sw_sanitize|escape }}',
+            confirmMyAddressCheckbox: '{{ "enderecoshopware6client.texts.confirmMyAddressCheckbox"|trans|sw_sanitize|escape }}',
+            notFoundSubline: '{{ "enderecoshopware6client.texts.notFoundSubline"|trans|sw_sanitize|escape }}',
+            yourInput: '{{ "enderecoshopware6client.texts.yourInput"|trans|sw_sanitize|escape }}',
+            editYourInput: '{{ "enderecoshopware6client.texts.editYourInput"|trans|sw_sanitize|escape }}',
+            ourSuggestions: '{{ "enderecoshopware6client.texts.ourSuggestions"|trans|sw_sanitize|escape }}',
+            useSelected: '{{ "enderecoshopware6client.texts.useSelected"|trans|sw_sanitize|escape }}',
+            confirmAddress: '{{ "enderecoshopware6client.texts.confirmAddress"|trans|sw_sanitize|escape }}',
+            editAddress: '{{ "enderecoshopware6client.texts.editAddress"|trans|sw_sanitize|escape }}',
+            warningText: '{{ "enderecoshopware6client.texts.warningText"|trans|sw_sanitize|escape }}',
+            popupHeadlines: {
+              general_address: '{{ "enderecoshopware6client.texts.general_address"|trans|sw_sanitize|escape }}',
+              billing_address: '{{ "enderecoshopware6client.texts.billing_address"|trans|sw_sanitize|escape }}',
+              shipping_address: '{{ "enderecoshopware6client.texts.shipping_address"|trans|sw_sanitize|escape }}',
+            },
+            statuses: {
+              email_not_correct: '{{ "enderecoshopware6client.statuses.email_not_correct"|trans|sw_sanitize|escape }}',
+              email_cant_receive: '{{ "enderecoshopware6client.statuses.email_cant_receive"|trans|sw_sanitize|escape }}',
+              email_syntax_error: '{{ "enderecoshopware6client.statuses.email_syntax_error"|trans|sw_sanitize|escape }}',
+              email_no_mx: '{{ "enderecoshopware6client.statuses.email_no_mx"|trans|sw_sanitize|escape }}',
+              building_number_is_missing: '{{ "enderecoshopware6client.statuses.building_number_is_missing"|trans|sw_sanitize|escape }}',
+              building_number_not_found: '{{ "enderecoshopware6client.statuses.building_number_not_found"|trans|sw_sanitize|escape }}',
+              street_name_needs_correction: '{{ "enderecoshopware6client.statuses.street_name_needs_correction"|trans|sw_sanitize|escape }}',
+              locality_needs_correction: '{{ "enderecoshopware6client.statuses.locality_needs_correction"|trans|sw_sanitize|escape }}',
+              postal_code_needs_correction: '{{ "enderecoshopware6client.statuses.postal_code_needs_correction"|trans|sw_sanitize|escape }}',
+              country_code_needs_correction: '{{ "enderecoshopware6client.statuses.country_code_needs_correction"|trans|sw_sanitize|escape }}',
+              phone_invalid: '{{ "enderecoshopware6client.statuses.phone_invalid"|trans|sw_sanitize|escape }}',
+              phone_format_needs_correction: '{{ "enderecoshopware6client.statuses.phone_format_needs_correction"|trans|sw_sanitize|escape }}',
+              phone_should_be_fixed: '{{ "enderecoshopware6client.statuses.phone_should_be_fixed"|trans|sw_sanitize|escape }}',
+              phone_should_be_mobile: '{{ "enderecoshopware6client.statuses.phone_should_be_mobile"|trans|sw_sanitize|escape }}',
+            },
+            requiredFormat: {
               E164: '{{ "enderecoshopware6client.requiredFormat.hintFormatE164"|trans|sw_sanitize|escape }}',
               INTERNATIONAL: '{{ "enderecoshopware6client.requiredFormat.hintFormatInternational"|trans|sw_sanitize|escape }}',
               NATIONAL: '{{ "enderecoshopware6client.requiredFormat.hintFormatNational"|trans|sw_sanitize|escape }}',
+            }
+          };
+          window.EnderecoIntegrator.activeServices = {
+            ams: true,
+            emailService: false,
+            personService: false,
+            phs: {{ page.endereco_config.enderecoPhsActive ? 'true':'false' }}
           }
-      };
-      window.EnderecoIntegrator.activeServices = {
-        ams: true,
-        emailService: false,
-        personService: false,
-        phs: {{ page.endereco_config.enderecoPhsActive ? 'true':'false' }}
-      }
 
-      // Execute all function that have been called throughout the page.
-      window.EnderecoIntegrator.onLoad.forEach(function (callback) {
-        callback();
-      });
+          // Execute all function that have been called throughout the page.
+          window.EnderecoIntegrator.onLoad.forEach(function (callback) {
+            callback();
+          });
 
-      window.EnderecoIntegrator.ready = true;
+          window.EnderecoIntegrator.ready = true;
 
-      (function() {
-        window.EnderecoIntegrator.$formScanner = {
-          loop: null,
-          start: function() {
-            this.loop = setInterval( function() {
-              document.querySelectorAll('[name="endereco_data_marker"][data-has-object="no"]').forEach( function(MarkerElement) {
-                var formElement = MarkerElement.closest('form');
-                var formId = '';
-                if (formElement.getAttribute('data-endereco-ams-form-id')) {
-                  formId = formElement.getAttribute('data-endereco-ams-form-id');
-                } else {
-                  formId = (Math.floor(Math.random() * 100) * Date.now()).toString(16);
-                  formElement.setAttribute('data-endereco-ams-form-id', formId);
-                }
-                if ('ams' === MarkerElement.value) {
-                  var prefix = MarkerElement.getAttribute('data-used-prefix');
-                  var countryCodeSelector = MarkerElement.getAttribute('data-country-code-selector');
-                  var postalCodeSelector = MarkerElement.getAttribute('data-postal-code-selector');
-                  var localitySelector = MarkerElement.getAttribute('data-locality-selector');
-                  var streetFullSelector = MarkerElement.getAttribute('data-street-full-selector');
-                  var streetSelector = MarkerElement.getAttribute('data-street-selector');
-                  var houseNumberSelector = MarkerElement.getAttribute('data-house-number-selector');
-                  var subdivisionCodeSelector = MarkerElement.getAttribute('data-subdivision-code-selector');
-                  var phoneSelector = MarkerElement.getAttribute('data-phone-selector');
-                  var isAjax = 'true' === MarkerElement.getAttribute('data-form-handle-ajax-submit');
-                  var EAO = window.EnderecoIntegrator.initAMS(
-                          {
-                            countryCode: `[data-endereco-ams-form-id="${formId}"] [name="${countryCodeSelector}"]`,
-                            subdivisionCode:  `[data-endereco-ams-form-id="${formId}"] [name="${subdivisionCodeSelector}"]`,
-                            postalCode: `[data-endereco-ams-form-id="${formId}"] [name="${postalCodeSelector}"]`,
-                            locality: `[data-endereco-ams-form-id="${formId}"] [name="${localitySelector}"]`,
-                            streetFull: `[data-endereco-ams-form-id="${formId}"] [name="${streetFullSelector}"]`,
-                            streetName: `[data-endereco-ams-form-id="${formId}"] [name="${streetSelector}"]`,
-                            buildingNumber: `[data-endereco-ams-form-id="${formId}"] [name="${houseNumberSelector}"]`,
-                          }, {
-                            name: `ams_${prefix}_${formId}`,
-                            addressType: 'general_address',
-                            ajaxForm: isAjax
-                          }
-                  );
+          (function() {
+            window.EnderecoIntegrator.$formScanner = {
+              loop: null,
+              start: function() {
+                this.loop = setInterval( function() {
+                  document.querySelectorAll('[name="endereco_data_marker"][data-has-object="no"]').forEach( function(MarkerElement) {
+                    var formElement = MarkerElement.closest('form');
+                    var formId = '';
+                    if (formElement.getAttribute('data-endereco-ams-form-id')) {
+                      formId = formElement.getAttribute('data-endereco-ams-form-id');
+                    } else {
+                      formId = (Math.floor(Math.random() * 100) * Date.now()).toString(16);
+                      formElement.setAttribute('data-endereco-ams-form-id', formId);
+                    }
+                    if ('ams' === MarkerElement.value) {
+                      var prefix = MarkerElement.getAttribute('data-used-prefix');
+                      var countryCodeSelector = MarkerElement.getAttribute('data-country-code-selector');
+                      var postalCodeSelector = MarkerElement.getAttribute('data-postal-code-selector');
+                      var localitySelector = MarkerElement.getAttribute('data-locality-selector');
+                      var streetFullSelector = MarkerElement.getAttribute('data-street-full-selector');
+                      var streetSelector = MarkerElement.getAttribute('data-street-selector');
+                      var houseNumberSelector = MarkerElement.getAttribute('data-house-number-selector');
+                      var subdivisionCodeSelector = MarkerElement.getAttribute('data-subdivision-code-selector');
+                      var phoneSelector = MarkerElement.getAttribute('data-phone-selector');
+                      var isAjax = 'true' === MarkerElement.getAttribute('data-form-handle-ajax-submit');
+                      var EAO = window.EnderecoIntegrator.initAMS(
+                              {
+                                countryCode: `[data-endereco-ams-form-id="${formId}"] [name="${countryCodeSelector}"]`,
+                                subdivisionCode:  `[data-endereco-ams-form-id="${formId}"] [name="${subdivisionCodeSelector}"]`,
+                                postalCode: `[data-endereco-ams-form-id="${formId}"] [name="${postalCodeSelector}"]`,
+                                locality: `[data-endereco-ams-form-id="${formId}"] [name="${localitySelector}"]`,
+                                streetFull: `[data-endereco-ams-form-id="${formId}"] [name="${streetFullSelector}"]`,
+                                streetName: `[data-endereco-ams-form-id="${formId}"] [name="${streetSelector}"]`,
+                                buildingNumber: `[data-endereco-ams-form-id="${formId}"] [name="${houseNumberSelector}"]`,
+                              }, {
+                                name: `ams_${prefix}_${formId}`,
+                                addressType: 'general_address',
+                                ajaxForm: isAjax
+                              }
+                      );
 
-                  window.EnderecoIntegrator.initPhoneServices(
-                      {
-                          phone: `[data-endereco-ams-form-id="${formId}"] [name="${phoneSelector}"]`,
-                          countryCode: `[data-endereco-ams-form-id="${formId}"] [name="${countryCodeSelector}"]`
-                      }, {
-                          name: `phs_${prefix}_${formId}`,
-                          addressType: 'general_address_phs'
-                      }
-                  );
-                }
-                MarkerElement.setAttribute('data-has-object', 'yes');
-              });
-            }, 1);
-          },
-          stop: function() {
+                      window.EnderecoIntegrator.initPhoneServices(
+                              {
+                                phone: `[data-endereco-ams-form-id="${formId}"] [name="${phoneSelector}"]`,
+                                countryCode: `[data-endereco-ams-form-id="${formId}"] [name="${countryCodeSelector}"]`
+                              }, {
+                                name: `phs_${prefix}_${formId}`,
+                                addressType: 'general_address_phs'
+                              }
+                      );
+                    }
+                    MarkerElement.setAttribute('data-has-object', 'yes');
+                  });
+                }, 1);
+              },
+              stop: function() {
 
-          }
+              }
+            }
+            window.EnderecoIntegrator.$formScanner.start();
+          })();
         }
-        window.EnderecoIntegrator.$formScanner.start();
-      })();
-    }
 
-    function enderecoLoadAMSConfig() {
-      var $interval = setInterval( function() {
-        if (!!window.EnderecoIntegrator.config) {
-          enderecoSetConfigValues();
-          clearInterval($interval);
+        function enderecoLoadAMSConfig() {
+          var $interval = setInterval( function() {
+            if (!!window.EnderecoIntegrator.config) {
+              enderecoSetConfigValues();
+              clearInterval($interval);
+            }
+          }, 1);
         }
-      }, 1);
-    }
-  </script>
-  {% endif %}
-
+      </script>
+    {% endif %}
+  {% endblock%}
   {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
When endereco plugin is installed, it changes some parts in the templates. Sometimes it might be usefull to be able to not display those changes.
In this change we add blocks around all template extensions endereco does.