### PR TITLE
Prevent data loading, when data would not be used anyways

### DIFF
--- a/src/Service/AddDataToPage.php
+++ b/src/Service/AddDataToPage.php
@@ -74,6 +74,26 @@ class AddDataToPage implements EventSubscriberInterface
                 ->get('EnderecoShopware6Client.config.enderecoActiveInThisChannel', $salesChannelId)
             && !empty($configContainer->enderecoApiKey);
 
+        // Enrich with advanced settings.
+        $this->addAdvancedSettingsData($configContainer, $context, $salesChannelId);
+
+        $currentController = (string) $event->getRequest()->attributes->get('_controller');
+
+        if ($currentController !== '' && $configContainer->controllerOnlyWhitelist) {
+            $found = false;
+
+            foreach ($configContainer->controllerWhitelist as $whitelist) {
+                if (\str_contains($currentController, "Controller\\${whitelist}Controller::")) {
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (!$found) {
+                return;
+            }
+        }
+
         // Enrich with email check settings.
         $this->addEmailCheckData($configContainer, $context, $salesChannelId);
 
@@ -85,9 +105,6 @@ class AddDataToPage implements EventSubscriberInterface
 
         // Enrich phone check settings.
         $this->addPhoneCheckData($configContainer, $context, $salesChannelId);
-
-        // Enricht with advanced settings.
-        $this->addAdvancedSettingsData($configContainer, $context, $salesChannelId);
 
         $event->getPage()->assign(['endereco_config' => $configContainer]);
     }


### PR DESCRIPTION
Loading countries does not need to be done, when we have e.g. a search suggest action. There is no address input at all. You are paying respect to that as you do not add the Javascript to that. But you still load all the necessary data. You still load e.g. countries from the database although they won't be used.

I suggest an early return to disable your integration when not needed. I follow the type check from the template you used converting the regex pattern of `\Shopware\Storefront\Framework\Twig\TemplateDataExtension` to your code.