### PR TITLE
fix: deprecation warning

### DIFF
--- a/src/Service/AddDataToPage.php
+++ b/src/Service/AddDataToPage.php
@@ -89,7 +89,7 @@ class AddDataToPage implements EventSubscriberInterface
         if ($isCurrentControllerKnown && $isControllerWhitelistActive) {
             $loadEnderecoSettings = false;
             foreach ($configContainer->controllerWhitelist as $whitelist) {
-                if (\str_contains($currentController, "Controller\\${whitelist}Controller::")) {
+                if (\str_contains($currentController, "Controller\\{$whitelist}Controller::")) {
                     $loadEnderecoSettings = true;
                     break;
                 }


### PR DESCRIPTION
Fix warning: "Deprecated: Using ${var} in strings is deprecated, use {$var} instead"