### PR TITLE
Fix cached address validation session ID reuse and cache key collision

### DIFF
--- a/src/Service/AddressCheck/AddressCheckerWithCache.php
+++ b/src/Service/AddressCheck/AddressCheckerWithCache.php
@@ -33,6 +33,19 @@ final class AddressCheckerWithCache implements AddressCheckerInterface
         $this->addressCheckPayloadBuilder = $addressCheckPayloadBuilder;
         $this->addressChecker = $addressChecker;
     }
+
+    /**
+     * Performs address validation with caching support.
+     *
+     * For cache misses: validates address, caches result without session ID, returns original with session ID
+     * For cache hits: returns cached result (which already has no session ID)
+     *
+     * @param CustomerAddressEntity $addressEntity The address entity to validate
+     * @param Context $context The Shopware context
+     * @param string $salesChannelId The sales channel ID
+     * @param string $sessionId Session ID for fresh validations
+     * @return AddressCheckResult Validation result
+     */
     public function checkAddress(
         CustomerAddressEntity $addressEntity,
         Context $context,
@@ -42,31 +55,63 @@ final class AddressCheckerWithCache implements AddressCheckerInterface
         $dataHash = $this->generateDataHash($addressEntity, $context);
         $cacheKey = sprintf(self::CACHE_KEY_TEMPLATE, $dataHash);
 
-        return $this->cache->get(
-            $cacheKey,
-            function (ItemInterface $item) use (
+        $freshResult = null;
+
+        $cachedResult = $this->cache->get($cacheKey, function (ItemInterface $item) use (
+            $addressEntity,
+            $context,
+            $salesChannelId,
+            $sessionId,
+            &$freshResult
+        ): AddressCheckResult {
+            // Cache miss - perform fresh validation
+            $freshResult = $this->addressChecker->checkAddress(
                 $addressEntity,
                 $context,
                 $salesChannelId,
                 $sessionId
-            ): AddressCheckResult {
-                $item->tag(self::CACHE_TAG);
-                $item->expiresAfter(self::CACHE_TTL);
+            );
 
-                return $this->addressChecker->checkAddress(
-                    $addressEntity,
-                    $context,
-                    $salesChannelId,
-                    $sessionId
-                );
-            }
-        );
+            // Cache copy without session ID
+            $cachedCopy = clone $freshResult;
+            $cachedCopy->setUsedSessionId('');
+
+            $item->tag(self::CACHE_TAG);
+            $item->expiresAfter(self::CACHE_TTL);
+
+            return $cachedCopy;
+        });
+
+        // If freshResult is set, callback was executed (cache miss) - return fresh result with session ID
+        // If freshResult is null, cache hit - return cached result (without session ID)
+        return $freshResult ?? $cachedResult;
     }
 
+    /**
+     * Generates a hash for cache key that includes both address content and entity ID.
+     *
+     * This ensures that different address entities with identical content (e.g., during QA testing)
+     * generate separate cache entries, preventing cache collisions and ensuring proper billing.
+     *
+     * @param CustomerAddressEntity $addressEntity The address entity to generate hash for
+     * @param Context $context The Shopware context
+     * @return string MD5 hash combining address content and entity ID
+     */
     private function generateDataHash(CustomerAddressEntity $addressEntity, Context $context): string
     {
         $addressCheckPayload = $this->addressCheckPayloadBuilder->buildFromCustomerAddress($addressEntity, $context);
 
-        return md5($addressCheckPayload->toJSON());
+        // Include address entity ID to ensure different records with same content get separate cache entries
+        $cacheData = [
+            'addressContent' => $addressCheckPayload->toJSON(),
+            'entityId' => $addressEntity->getId()
+        ];
+
+        $jsonData = json_encode($cacheData);
+        if ($jsonData === false) {
+            throw new \RuntimeException('Failed to encode cache data to JSON');
+        }
+
+        return md5($jsonData);
     }
 }

--- a/src/Service/AddressIntegrity/CustomerAddress/AmsStatusIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/AmsStatusIsSetInsurance.php
@@ -135,7 +135,7 @@ final class AmsStatusIsSetInsurance implements IntegrityInsurance
         }
 
         // Count the validation for accounting.
-        if (!empty($sessionId)) {
+        if ($sessionId !== '') {
             $this->enderecoService->addAccountableSessionIdsToStorage([$sessionId]);
         }
     }


### PR DESCRIPTION
Cached address validation results were reusing old session IDs and identical address content from different records shared cache entries. This caused billing issues with abandoned sessions and prevented proper QA testing with duplicate addresses across different customers.

The cache key now includes entity ID alongside address content, and session IDs are cleared for cached results to prevent reuse of old sessions.