### PR TITLE
🔧 Fix order address extension data loss and loading errors during order updates

### DIFF
--- a/src/Entity/CustomerAddress/CustomerAddressExtension.php
+++ b/src/Entity/CustomerAddress/CustomerAddressExtension.php
@@ -28,7 +28,7 @@ class CustomerAddressExtension extends EntityExtension
                 'id',
                 'address_id',
                 EnderecoCustomerAddressExtensionDefinition::class,
-                true
+                true // This is marked as bad practise by Shopware and should be replaced with conditional loading.
             )
         );
     }

--- a/src/Entity/EnderecoAddressExtension/CustomerAddress/EnderecoCustomerAddressExtensionDefinition.php
+++ b/src/Entity/EnderecoAddressExtension/CustomerAddress/EnderecoCustomerAddressExtensionDefinition.php
@@ -7,6 +7,8 @@ namespace Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddre
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\EnderecoBaseAddressExtensionDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 
 class EnderecoCustomerAddressExtensionDefinition extends EnderecoBaseAddressExtensionDefinition
@@ -41,7 +43,10 @@ class EnderecoCustomerAddressExtensionDefinition extends EnderecoBaseAddressExte
      */
     protected function addressAssociationForeignKeyField(): FkField
     {
-        return new FkField('address_id', 'addressId', CustomerAddressDefinition::class);
+        $field = new FkField('address_id', 'addressId', CustomerAddressDefinition::class);
+        $field->addFlags(new Required(), new PrimaryKey());
+
+        return $field;
     }
 
     /**

--- a/src/Entity/EnderecoAddressExtension/CustomerAddress/EnderecoCustomerAddressExtensionEntity.php
+++ b/src/Entity/EnderecoAddressExtension/CustomerAddress/EnderecoCustomerAddressExtensionEntity.php
@@ -8,6 +8,7 @@ use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\EnderecoBaseAddress
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * Class EnderecoCustomerAddressExtensionEntity
@@ -70,6 +71,8 @@ class EnderecoCustomerAddressExtensionEntity extends EnderecoBaseAddressExtensio
     public function createOrderAddressExtension(string $orderAddressId): EnderecoOrderAddressExtensionEntity
     {
         $entity = new EnderecoOrderAddressExtensionEntity();
+        $entity->setId(Uuid::randomHex());
+        $entity->setUniqueIdentifier($entity->getId());
         $entity->setAddressId($orderAddressId);
         $entity->setAmsStatus($this->getAmsStatus());
         $entity->setAmsTimestamp($this->getAmsTimestamp());

--- a/src/Entity/EnderecoAddressExtension/EnderecoBaseAddressExtensionDefinition.php
+++ b/src/Entity/EnderecoAddressExtension/EnderecoBaseAddressExtensionDefinition.php
@@ -31,7 +31,7 @@ abstract class EnderecoBaseAddressExtensionDefinition extends EntityDefinition
     {
         return new FieldCollection([
             // The primary key field linked to the address.
-            $this->addressAssociationForeignKeyField()->addFlags(new Required(), new PrimaryKey()),
+            $this->addressAssociationForeignKeyField(),
 
             // A field that contains a JSON array of predictions for possible address corrections.
             (new LongTextField('ams_request_payload', 'amsRequestPayload')),
@@ -63,7 +63,9 @@ abstract class EnderecoBaseAddressExtensionDefinition extends EntityDefinition
     }
 
     /**
-     * Creates FK field for address association
+     * Creates FK field for address association.
+     *
+     * The returned FKField must be flagged inside the method. No flags will be added in the base class.
      *
      * @return FkField Foreign key field configuration
      */

--- a/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionEntity.php
+++ b/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionEntity.php
@@ -6,9 +6,10 @@ namespace Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress;
 
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\EnderecoBaseAddressExtensionEntity;
 use Endereco\Shopware6Client\Model\AddressCheckData;
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * Class EnderecoOrderAddressExtensionEntity
@@ -23,8 +24,80 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
  */
 class EnderecoOrderAddressExtensionEntity extends EnderecoBaseAddressExtensionEntity
 {
+    /** @var string The ID of this entity. */
+    protected string $id;
+
+    // The version ID of this entity is defined in the base entity class of Shopware.
+
+    /** @var string The version ID of the associated address. */
+    protected string $addressVersionId;
+
     /** @var ?OrderAddressEntity The associated order address entity. */
     protected ?OrderAddressEntity $address = null;
+
+    /**
+     * Creates an order address extension instance with a random UUID and the default AMS data.
+     * An order address ID is mandatory. An order address version ID is optional.
+     *
+     * @param string $addressId
+     * @param string|null $addressVersionId
+     * @return EnderecoOrderAddressExtensionEntity
+     */
+    public static function createWithDefaultValues(
+        string $addressId,
+        ?string $addressVersionId
+    ): EnderecoOrderAddressExtensionEntity {
+        $addressExtension = new EnderecoOrderAddressExtensionEntity();
+        $addressExtension->setId(Uuid::randomHex());
+        $addressExtension->setUniqueIdentifier($addressExtension->getId());
+        $addressExtension->setVersionId(Defaults::LIVE_VERSION);
+        $addressExtension->setAddressId($addressId);
+        if (is_string($addressVersionId)) {
+            $addressExtension->setAddressVersionId($addressVersionId);
+        }
+
+        return $addressExtension;
+    }
+
+    /**
+     * Get the ID.
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set ID.
+     *
+     * @param string $id
+     */
+    public function setId(string $id): void
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Get address version ID.
+     *
+     * @return string The version ID of the associated address.
+     */
+    public function getAddressVersionId(): string
+    {
+        return $this->addressVersionId;
+    }
+
+    /**
+     * Set address version ID.
+     *
+     * @param string $addressId The version ID of the associated address.
+     */
+    public function setAddressVersionId(string $addressId): void
+    {
+        $this->addressVersionId = $addressId;
+    }
 
     /**
      * Gets the associated order address entity.

--- a/src/Entity/OrderAddress/OrderAddressExtension.php
+++ b/src/Entity/OrderAddress/OrderAddressExtension.php
@@ -7,6 +7,7 @@ namespace Endereco\Shopware6Client\Entity\OrderAddress;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -21,15 +22,18 @@ class OrderAddressExtension extends EntityExtension
      */
     public function extendFields(FieldCollection $collection): void
     {
-        $collection->add(
-            new OneToOneAssociationField(
-                self::ENDERECO_EXTENSION,
-                'id',
-                'address_id',
-                EnderecoOrderAddressExtensionDefinition::class,
-                true
-            )
+        $associationField = new OneToOneAssociationField(
+            self::ENDERECO_EXTENSION,
+            'id',
+            'address_id',
+            EnderecoOrderAddressExtensionDefinition::class,
+            true // This is marked as bad practise by Shopware and should be replaced with conditional loading.
         );
+        // The CascadeDelete flag tells Shopware that this extension is marked as cascade delete in the database.
+        // Shopware will only version-copy extensions that are flagged like this during it's merge process.
+        // This prevents the loss of this data in process.
+        $associationField->addFlags(new CascadeDelete());
+        $collection->add($associationField);
     }
 
     /**

--- a/src/Migration/Migration1753461221AddAddressIdColumnToOrderAddressExtensions.php
+++ b/src/Migration/Migration1753461221AddAddressIdColumnToOrderAddressExtensions.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1753461221AddAddressIdColumnToOrderAddressExtensions extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1753461221;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @throws Exception
+     */
+    public function update(Connection $connection): void
+    {
+        $sql = <<<SQL
+        ALTER TABLE `endereco_order_address_ext_gh`
+            ADD COLUMN `id` BINARY(16) NOT NULL FIRST,
+            ADD COLUMN `version_id` BINARY(16) NOT NULL AFTER `id`,
+            ADD COLUMN `address_version_id` BINARY(16) NOT NULL AFTER `address_id`
+        SQL;
+        $connection->executeStatement($sql);
+
+        // The version IDs can be set to the Shopware Default version ID for the migration.
+        $sql = <<<SQL
+        UPDATE `endereco_order_address_ext_gh`
+            SET `version_id` = UNHEX("0fa91ce3e96a4bc2be4bd9ce752c3425"),
+                `address_version_id` = UNHEX("0fa91ce3e96a4bc2be4bd9ce752c3425")
+        SQL;
+        $connection->executeStatement($sql);
+
+        // UUID() is used to generate random UUIDs for existing order addresses.
+        $sql = <<<SQL
+        CREATE TEMPORARY TABLE `temp_uuids` 
+               AS SELECT `address_id`, UNHEX(REPLACE(UUID(), '-', '')) AS `new_id` FROM `endereco_order_address_ext_gh`
+        SQL;
+        $connection->executeStatement($sql);
+
+        $sql = <<<SQL
+        UPDATE `endereco_order_address_ext_gh` `t1` JOIN `temp_uuids` `t2` ON `t1`.`address_id` = `t2`.`address_id` 
+            SET `t1`.`id` = `t2`.`new_id`
+        SQL;
+        $connection->executeStatement($sql);
+
+        // The constraint must be dropped before the primary key because it uses the primary key.
+        $sql = <<<SQL
+        ALTER TABLE `endereco_order_address_ext_gh`
+            DROP CONSTRAINT `fk.end_order_address_id_gh`
+        SQL;
+        $connection->executeStatement($sql);
+
+        $sql = <<<SQL
+        ALTER TABLE `endereco_order_address_ext_gh`
+            DROP PRIMARY KEY,
+            ADD PRIMARY KEY (`id`, `version_id`)
+        SQL;
+        $connection->executeStatement($sql);
+
+        $sql = <<<SQL
+        ALTER TABLE `endereco_order_address_ext_gh`
+            ADD CONSTRAINT `fk.end_order_address_id_gh` 
+                FOREIGN KEY (`address_id`, `address_version_id`) 
+                    REFERENCES `order_address` (`id`, `version_id`) ON UPDATE CASCADE ON DELETE CASCADE
+        SQL;
+        $connection->executeStatement($sql);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Service/AddressIntegrity/OrderAddress/AddressExtensionExistsInsurance.php
+++ b/src/Service/AddressIntegrity/OrderAddress/AddressExtensionExistsInsurance.php
@@ -7,6 +7,8 @@ use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
 
 final class AddressExtensionExistsInsurance implements IntegrityInsurance
 {
@@ -32,8 +34,14 @@ final class AddressExtensionExistsInsurance implements IntegrityInsurance
     public function ensure(OrderAddressEntity $addressEntity, Context $context): void
     {
         $addressExtension = $addressEntity->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
-
         if ($addressExtension instanceof EnderecoOrderAddressExtensionEntity) {
+            return;
+        }
+
+        $persistedAddressExtension = $this->addressExtensionRepository->search(new Criteria([$addressEntity->getId()]), $context)->first();
+        if ($persistedAddressExtension instanceof EnderecoOrderAddressExtensionEntity) {
+            $addressEntity->addExtension(OrderAddressExtension::ENDERECO_EXTENSION, $persistedAddressExtension);
+
             return;
         }
 
@@ -50,12 +58,14 @@ final class AddressExtensionExistsInsurance implements IntegrityInsurance
         OrderAddressEntity $addressEntity,
         Context $context
     ): void {
-        /** @var EnderecoOrderAddressExtensionEntity $addressExtension */
-        $addressExtension = $this->createAddressExtensionWithDefaultValues($addressEntity);
+        $addressExtension = EnderecoOrderAddressExtensionEntity::createWithDefaultValues($addressEntity->getId(), $addressEntity->getVersionId());
 
         $this->addressExtensionRepository->upsert(
             [[
+                'id' => $addressExtension->getId(),
+                'versionId' => $addressEntity->getVersionId(),
                 'addressId' => $addressExtension->getAddressId(),
+                'addressVersionId' => $addressExtension->getAddressVersionId(),
                 'amsRequestPayload' => $addressExtension->getAmsRequestPayload(),
                 'amsStatus' => $addressExtension->getAmsStatus(),
                 'amsPredictions' => $addressExtension->getAmsPredictions(),
@@ -65,18 +75,6 @@ final class AddressExtensionExistsInsurance implements IntegrityInsurance
         );
 
         $this->addExtensionToAddressEntity($addressEntity, $addressExtension);
-    }
-
-    /**
-     * Creates new address extension with default values
-     */
-    protected function createAddressExtensionWithDefaultValues(
-        OrderAddressEntity $addressEntity
-    ): EnderecoOrderAddressExtensionEntity {
-        $addressExtension = new EnderecoOrderAddressExtensionEntity();
-        $addressExtension->setAddressId($addressEntity->getId());
-        $addressExtension->setAddress($addressEntity);
-        return $addressExtension;
     }
 
     /**

--- a/src/Subscriber/ConvertCartToOrderSubscriber.php
+++ b/src/Subscriber/ConvertCartToOrderSubscriber.php
@@ -131,6 +131,8 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
             if ($customerAddressExtension instanceof EnderecoCustomerAddressExtensionEntity) {
                 /** @var string $orderAddressId */
                 $orderAddressId = $address['id'];
+                // The address version ID is not yet set at this point.
+                // Shopware will automatically do that and use the relation to set it in the extension as well.
 
                 $orderAddressExtensionEntity = $customerAddressExtension->createOrderAddressExtension($orderAddressId);
                 $orderAddressExtensionData = $orderAddressExtensionEntity->buildCartToOrderConversionData();


### PR DESCRIPTION
## Problem

Two critical issues occurred when editing orders in the administration:

1. **Data Loss**: Order address extension data was permanently deleted when orders were edited. This happened because Shopware's versioning system creates new versions during editing and merges changes into a new live version. The extension entity lacked proper versioning support, causing CASCADE DELETE to remove all extension data during the merge process.

2. **Loading Errors**: The order list and order detail pages failed to load with persistence errors. Newly created extension entities were missing unique identifiers required by Shopware's downstream processes, causing the administration interface to break.

## Solution

### Versioning Support
- Added proper versioning fields to the order address extension entity:
  - `id` field as primary key
  - `version_id` for entity versioning
  - `address_version_id` to link to specific order address versions
- Updated database schema with composite primary key (`id`, `version_id`)
- Modified foreign key constraint to include version references
- Added `CascadeDelete` flag to inform Shopware about the database constraint

### Entity Integrity
- Set unique identifiers when creating extension entities
- Implemented proper entity initialization in:
  - `EnderecoOrderAddressExtensionEntity::createWithDefaultValues()`
  - `EnderecoCustomerAddressExtensionEntity::createOrderAddressExtension()`

### Database Migration
- Migration adds new columns to existing installations
- Generates UUIDs for existing records
- Updates constraints while preserving existing data

## Testing
- [ ] Order editing in administration works without data loss
- [ ] Order list loads without errors
- [ ] Extension data persists through order version changes
- [ ] Migration runs successfully on existing installations
- [ ] New installations work correctly

## Affected Versions
This fix applies to all Shopware 6.6.x versions where the order address extension is used.