### PR TITLE
feat: add configurable TTL for address check validation

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -713,5 +713,18 @@
                 Namen müssen mit "," getrennt eingeben werden.
             </helpText>
         </input-field>
+
+        <input-field type="int">
+            <name>enderecoAddressCheckTtl</name>
+            <label>Address validity period in minutes</label>
+            <label lang="de-DE">Adressgültigkeit in Minuten</label>
+            <defaultValue>30</defaultValue>
+            <helpText>
+                Time in minutes after address creation during which address validation is skipped (address is considered valid). After this period, the address will be validated again. Set to 0 to always validate addresses.
+            </helpText>
+            <helpText lang="de-DE">
+                Zeit in Minuten nach der Adresserstellung, während der die Adressvalidierung übersprungen wird (Adresse gilt als gültig). Nach dieser Zeit wird die Adresse erneut validiert. Auf 0 setzen, um Adressen immer zu validieren.
+            </helpText>
+        </input-field>
     </card>
 </config>

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -782,23 +782,33 @@ class EnderecoService
     }
 
     /**
-     * Checks if a given address was created within the last 30 minutes.
+     * Checks if a given address was created within the configured TTL period.
      *
      * @param CustomerAddressEntity $addressEntity The address entity to check.
      *
-     * @return bool Returns true if the address was created within the last 30 minutes, false otherwise.
+     * @return bool Returns true if the address was created within the configured TTL period, false otherwise.
      */
     public function isAddressRecent(CustomerAddressEntity $addressEntity): bool
     {
+        // Get the TTL configuration in minutes (default: 30 minutes)
+        $ttlMinutes = $this->systemConfigService->getInt(
+            'EnderecoShopware6Client.config.enderecoAddressCheckTtl'
+        ) ?: 30;
+
+        // If TTL is set to 0, address validation should always run (address is never considered recent)
+        if ($ttlMinutes === 0) {
+            return false;
+        }
+
         // Get the creation time of the address
         $creationTime = $addressEntity->getCreatedAt();
 
-        // Get the current time minus 30 minutes
-        $fiveMinutesAgo = (new \DateTime())->modify('-30 minutes');
+        // Get the current time minus the configured TTL
+        $ttlAgo = (new \DateTime())->modify('-' . $ttlMinutes . ' minutes');
 
-        // If the creation time of the address is greater than (or equal to) the time 30 minutes ago, return true
+        // If the creation time of the address is greater than (or equal to) the TTL threshold, return true
         // Otherwise, return false
-        return $creationTime >= $fiveMinutesAgo;
+        return $creationTime >= $ttlAgo;
     }
 
     /**


### PR DESCRIPTION
- Add configurable TTL for address check validation to allow shop owners to customize how long addresses are considered "recent" and skip validation
- Add new config field enderecoAddressCheckTtl in Advanced Configuration section (default: 30 minutes, set to 0 to always validate)
- Modify isAddressRecent() method in EnderecoService.php to use the configurable TTL instead of hardcoded 30 minutes