### PR TITLE
Fix 'ESC doesn't work' for update JS-SDK to 1.14.0

### DIFF
--- a/endereco.js
+++ b/endereco.js
@@ -372,3 +372,41 @@ const waitForConfig = setInterval(() => {
         clearInterval(waitForConfig);
     }
 }, 10);
+
+//Disable "Esc" keypress handling in input:focus inside address-form 
+//and if autocomplete-dropdown list is open
+function initEnderecoEscHandler() {
+
+    if (window.__enderecoEscHandlerAttached) {
+        return;
+    }
+    window.__enderecoEscHandlerAttached = true;
+
+    document.addEventListener('keydown', (e) => {
+        if (!document.body.classList.contains('modal-open')) {
+            return;
+        }
+
+        if (e.key !== 'Escape') {
+            return;
+        }
+
+        const active = document.activeElement;
+        if (!active || active.tagName !== 'INPUT') {
+            return;
+        }
+
+        const prediction = active.nextElementSibling;
+        if (!prediction || !prediction.classList.contains('endereco-predictions-wrapper')) {
+            return;
+        }
+
+        // stop modal ESC
+        e.stopPropagation();
+
+        // close only predictions
+        prediction.remove();
+    }, true);
+}
+
+initEnderecoEscHandler();


### PR DESCRIPTION
Add keydown handler for ESC (js).
If modal is open, focus is on an INPUT, and it`s autocomplete dropdown is present:
- prevent modal close
- remove autocomplete dropdown. Otherwise fallback to default Shopware behavior.

Video-Report:
https://github.com/user-attachments/assets/4745ea46-30d9-4ac8-8066-c219b198bbb1


Ref: DEV-229

