### PR TITLE
Adjust PersonServices selectors for Shopware 6.7

### DIFF
--- a/src/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Resources/views/storefront/component/account/register.html.twig
@@ -1,24 +1,5 @@
 {% sw_extends '@Storefront/storefront/component/account/register.html.twig' %}
 
-{% block component_account_register_personal %}
-    {{ parent() }}
-    {% if page.endereco_config.pluginActive and ( not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}
-        <input
-            type="hidden"
-            name="endereco_data_marker"
-            value="personServices"
-            data-container-selector="form"
-            data-container-type="form"
-            data-used-prefix="register"
-            data-has-object="no"
-            data-first-name-selector="[name='firstName']"
-            data-last-name-selector="[name='lastName']"
-            data-salutation-selector="[name='salutationId']"
-            data-title-selector="[name='title']"
-        >
-    {% endif %}
-{% endblock %}
-
 {% block component_account_register_personal_mail %}
     {{ parent() }}
     {% if page.endereco_config.pluginActive and ( not page.endereco_config.controllerOnlyWhitelist or controllerName in page.endereco_config.controllerWhitelist ) %}

--- a/src/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Resources/views/storefront/component/address/address-form.html.twig
@@ -53,6 +53,9 @@
                         data-phone-selector="[name='{{ prefix }}[phoneNumber]']"
                 >
 
+               {# In Shopware 6.7, the `name` property of the `personalSalutation` and `personalTitle` select elements in billing addresses do not
+                   include a prefix. Therefore, conditional checks have been added for the `data-salutation-selector` attribute to handle this 
+                   difference and ensure proper field mapping. #}
                 <input
                         type="hidden"
                         name="endereco_data_marker"
@@ -63,8 +66,8 @@
                         data-has-object="no"
                         data-first-name-selector="[name='{{ prefix }}[firstName]']"
                         data-last-name-selector="[name='{{ prefix }}[lastName]']"
-                        data-salutation-selector="[name='{{ prefix }}[salutationId]']"
-                        data-title-selector="[name='{{ prefix }}[title]']"
+                        data-salutation-selector="[name='{% if prefix == 'billingAddress' %}salutationId{% else %}{{ prefix }}[salutationId]{% endif %}']"
+                        data-title-selector="[name='{% if prefix == 'billingAddress' %}title{% else %}{{ prefix }}[title]{% endif %}']"
                 >
 
                 {% set amsStatus = '' %}


### PR DESCRIPTION
Shopware 6.7 changed the registration form field naming:
- Salutation: salutationId (no prefix)
- Names: billingAddress[firstName/lastName] (with prefix)

This resulted in Salutation, FirstName und LastName fields not working properly in the billing address forms on registration and guestorder pages. Salutation field was not set automatically, personCheck() caused an unhandled Promise Rejection.

Updated selectors in address-form.html.twig . Removed personServices-Marker in register.html.twig, as all possible use cases (billingAddress, shippingAddress, address) are now covered by address-form.html.twig.
The new structure is now matched and no validation errors occur.

Ref: DEV-264 (based on S6A-304)

Tested against Shopware 6.7.1.2, 6.7.4.2, 6.7.5.1
Videos with 6.7.1.2 and 6.7.5.1:
https://www.loom.com/share/b953099529e442c282be32766569dd90
https://www.loom.com/share/887895d1048b4d108eea11edac45b885
https://www.loom.com/share/d98ce7cf63904a968acc01d90bcc75af
https://www.loom.com/share/60e85a00d51d423b8617e2349ffd6db9