### PR TITLE
MySQL 8.4 Compatibility (6.7 Backport)

### DIFF
--- a/check_mysql_compatibility.sh
+++ b/check_mysql_compatibility.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# MySQL version to check
+mysql_versions=("8.0" "8.1" "8.2" "8.3" "8.4")
+
+# Shopware version for dockware image
+shopware_version="6.7.0.1"
+
+# Plugin variables
+plugin_host_dir="./"  # Directory on host where your plugin files are stored
+plugin_container_dir="/var/www/html/custom/plugins/EnderecoShopware6Client"  # Directory in the container where plugins are stored
+
+base_container_name="check_mysql_compatibility"
+network_name="${base_container_name}_network"
+
+# Mysql variables
+mysql_container_name="${base_container_name}_mysql"
+mysql_user=shopware
+mysql_password=shopware
+mysql_database=shopware
+mysql_environment_variables="
+-e MYSQL_USER=${mysql_user}
+-e MYSQL_PASSWORD=${mysql_password}
+-e MYSQL_DATABASE=${mysql_database}
+-e MYSQL_RANDOM_ROOT_PASSWORD=yes
+"
+
+# Dockware variables
+dockware_container_name="${base_container_name}_dockware"
+dockware_image="dockware/dev:$shopware_version"
+dockware_environment_variables="
+-e DATABASE_URL=mysql://${mysql_user}:${mysql_password}@${mysql_container_name}/${mysql_database}
+"
+
+# Setup containers, copy plugin into dockware container, expects mysql version as first and only argument
+setup() {
+  # Create network for communication between dockware and mysql container, no port mappings required
+    docker network create $network_name
+
+    # Create mysql container with tmpfs and performance tuning
+    docker run \
+        -d \
+        $mysql_environment_variables \
+        --name $mysql_container_name \
+        --network=$network_name \
+        --tmpfs /var/lib/mysql:rw,size=2g \
+        --tmpfs /tmp:rw,size=512m \
+        --health-cmd="mysql -u $mysql_user -p$mysql_password -e 'SHOW TABLES;' $mysql_database > /dev/null || exit 1" \
+        --health-interval=5s \
+        --health-timeout=2s \
+        --health-retries=10 \
+        "mysql:$1" \
+        --innodb-flush-log-at-trx-commit=0 \
+        --innodb-buffer-pool-size=512M \
+        --innodb-log-file-size=256M \
+        --innodb-doublewrite=0 \
+        --sync-binlog=0 \
+        --skip-log-bin
+
+    # Wait until mysql container is healthy, fail when mysql container becomes unhealthy
+    until [ "$(docker inspect --format='{{json .State.Health.Status}}' "$mysql_container_name")" = "\"healthy\"" ]; do
+      health_status="$(docker inspect --format='{{json .State.Health.Status}}' "$mysql_container_name")"
+
+      if [ "$health_status" = "\"unhealthy\"" ]; then
+          echo "MySQL container health check failed (unhealthy)."
+          return 1
+      fi
+
+      echo "Waiting for MySQL container to become healthy..."
+      sleep 5
+    done
+
+    # Create dockware container with bind mounts for essential plugin files only
+    # Waiting for healthy not necessary, console is available right away
+    docker run \
+      -d \
+      $dockware_environment_variables \
+      --name $dockware_container_name \
+      --network=$network_name \
+      -v "$(pwd)/src:$plugin_container_dir/src" \
+      -v "$(pwd)/composer.json:$plugin_container_dir/composer.json" \
+      $dockware_image
+
+    # Install shopware in dockware container to run migrations in mysql container
+    # Needs --force to ignore the install.lock file
+    docker exec $dockware_container_name php bin/console system:install --force
+}
+
+# Checks mysql compatibility by installing the plugin
+run_mysql_compatibility_check() {
+  # Install and activate plugin via the console
+  docker exec $dockware_container_name php bin/console plugin:refresh
+  docker exec $dockware_container_name php bin/console plugin:install --activate EnderecoShopware6Client
+}
+
+# Stops and removes dockware and mysql container and the removes the network
+tear_down() {
+  docker stop $dockware_container_name
+  docker container rm $dockware_container_name
+  docker stop $mysql_container_name
+  docker container rm $mysql_container_name
+  docker network rm $network_name
+}
+
+for mysql_version in "${mysql_versions[@]}"; do
+  # setup containers
+  setup $mysql_version
+
+  # Run compatibility check
+  run_mysql_compatibility_check
+
+  # Check for failure, if so tear_down and exit
+  if [ $? -ne 0 ]; then
+    echo "compatibility check failed for mysql version $mysql_version"
+    tear_down
+    exit 1
+  fi
+
+  # Tear down after each MySQL version so that no running containers remain and the next check is restarted from scratch.
+  tear_down
+done

--- a/check_mysql_compatibility.sh
+++ b/check_mysql_compatibility.sh
@@ -4,7 +4,7 @@
 mysql_versions=("8.0" "8.1" "8.2" "8.3" "8.4")
 
 # Shopware version for dockware image
-shopware_version="6.7.0.1"
+shopware_version="6.6.10.6"
 
 # Plugin variables
 plugin_host_dir="./"  # Directory on host where your plugin files are stored

--- a/src/Migration/Migration1731623484CreateOrderAddressExtensionTable.php
+++ b/src/Migration/Migration1731623484CreateOrderAddressExtensionTable.php
@@ -16,29 +16,78 @@ class Migration1731623484CreateOrderAddressExtensionTable extends MigrationStep
     }
 
     /**
+     * @throws Exception
+     */
+    private function isGtMysql84(Connection $connection): bool
+    {
+        $isMariadb = (bool) $connection->executeQuery(<<<SQL
+        SELECT 
+            CASE
+                WHEN VERSION() LIKE '%MariaDB%' 
+                    OR @@version_comment LIKE '%MariaDB%' THEN 1
+                ELSE 0
+            END AS is_mariadb;
+        SQL)->fetchOne();
+
+        if ($isMariadb) {
+            return false;
+        }
+
+        $version = $connection->executeQuery(<<<SQL
+            SELECT VERSION()
+        SQL)->fetchOne();
+
+        return version_compare($version, '8.4', '>=');
+    }
+
+    /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @throws Exception
      */
     public function update(Connection $connection): void
     {
-        $sql = <<<SQL
-        CREATE TABLE IF NOT EXISTS `endereco_order_address_ext_gh` (
-            `address_id` BINARY(16) NOT NULL,
-            `ams_status` LONGTEXT NULL,
-            `ams_timestamp` INT NULL,
-            `ams_predictions` LONGTEXT NULL,
-            `is_amazon_pay_address` BOOLEAN NULL DEFAULT false,
-            `is_paypal_address` BOOLEAN NULL DEFAULT false,
-            `street` VARCHAR(255) NULL DEFAULT '',
-            `house_number` VARCHAR(255) NULL DEFAULT '',
-            `created_at` DATETIME(3) NOT NULL,
-            `updated_at` DATETIME(3) NULL,
-            PRIMARY KEY (`address_id`),
-            CONSTRAINT `fk.end_order_address_id_gh`
-                FOREIGN KEY (`address_id`) REFERENCES `order_address` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-        SQL;
+        if ($this->isGtMysql84($connection)) {
+            // Don't add order_address foreign key,
+            // added by Migration1753461221AddAddressIdColumnToOrderAddressExtensions.php
+            // because the migration won't run because of breaking changes in MySQL 8.4 in the default
+            // configuration
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS `endereco_order_address_ext_gh` (
+                `address_id` BINARY(16) NOT NULL,
+                `ams_status` LONGTEXT NULL,
+                `ams_timestamp` INT NULL,
+                `ams_predictions` LONGTEXT NULL,
+                `is_amazon_pay_address` BOOLEAN NULL DEFAULT false,
+                `is_paypal_address` BOOLEAN NULL DEFAULT false,
+                `street` VARCHAR(255) NULL DEFAULT '',
+                `house_number` VARCHAR(255) NULL DEFAULT '',
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`address_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL;
+        } else {
+            // in all cases where the migration already was executed nothing changes
+            // datamodels are adjusted in subsequent Migration1753461221AddAddressIDColumnToAdressExtensions.php
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS `endereco_order_address_ext_gh` (
+                `address_id` BINARY(16) NOT NULL,
+                `ams_status` LONGTEXT NULL,
+                `ams_timestamp` INT NULL,
+                `ams_predictions` LONGTEXT NULL,
+                `is_amazon_pay_address` BOOLEAN NULL DEFAULT false,
+                `is_paypal_address` BOOLEAN NULL DEFAULT false,
+                `street` VARCHAR(255) NULL DEFAULT '',
+                `house_number` VARCHAR(255) NULL DEFAULT '',
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`address_id`),
+                CONSTRAINT `fk.end_order_address_id_gh`
+                    FOREIGN KEY (`address_id`) REFERENCES `order_address` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL;
+        }
         $connection->executeStatement($sql);
     }
 


### PR DESCRIPTION
MySQL 8.4 Compatibility (6.7 Backport)

+ switch Shopware test-version to 6.6.10.6

Removed the constraint in CREATE if the MySQL-Version is higher or
equal than 8.4. We only adapt the non-executable migrations for
known failures in all database systems currently officially
supported by Shopware (MySQL > 8.0.22 and MariaDB > 10.11.6
or MariaDB> 11.0.4), which can be found here:

https://developer.shopware.com/docs/guides/installation/requirements.html#sql

Migration1731623484 is altered only for MySQL-Versions >= 8.4
Since Migration1731623484 may already have been executed in systems
in the field, the same migration becomes executable for the remaining
systems that previously threw an error.

This should be the preferred implementation in order to guarantee
identical states on customer systems after identical migrations.
Subsequently we standardize all databases back to the same data model
in Migration1753461221 which is tested to run in all officially
supported configurations.

Other database technologies were not considered due to the scope of
the current branch.

Refs: [DEV-145](https://mobilemojo.atlassian.net/browse/DEV-145), #88

[DEV-145]: https://mobilemojo.atlassian.net/browse/DEV-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ