### PR TITLE
Add Snipptes in ES, FR, IT, NL

### DIFF
--- a/src/Resources/snippet/es_ES/storefront.es-ES.json
+++ b/src/Resources/snippet/es_ES/storefront.es-ES.json
@@ -1,0 +1,55 @@
+{
+    "enderecoshopware6client": {
+        "texts": {
+            "popUpHeadline": "Verificar dirección",
+            "popUpSubline": "La dirección que has introducido parece incorrecta o incompleta. Selecciona la dirección correcta.",
+            "yourInput": "Tus datos:",
+            "editYourInput": "(editar)",
+            "ourSuggestions": "Nuestras sugerencias:",
+            "useSelected": "Confirmar selección",
+            "general_address": "Verificar dirección",
+            "billing_address": "Verificar dirección de facturación",
+            "shipping_address": "Verificar dirección de envío",
+            "mistakeNoPredictionSubline": "No se ha podido verificar tu dirección. Revisa tus datos y modifícalos o confírmalos.",
+            "notFoundSubline": "No se ha podido verificar tu dirección. Revisa tus datos y modifícalos o confírmalos.",
+            "confirmAddress": "Confirmar dirección",
+            "editAddress": "Editar dirección",
+            "warningText": "Las direcciones incorrectas pueden provocar problemas en la entrega y generar costes adicionales.",
+            "confirmMyAddressCheckbox": "Confirmo que mi dirección es correcta y válida para la entrega."
+        },
+        "statuses": {
+            "email_not_correct": "La dirección de correo electrónico no parece ser correcta",
+            "email_cant_receive": "El buzón de correo electrónico no está disponible",
+            "email_syntax_error": "Comprueba la ortografía",
+            "email_no_mx": "La dirección de correo electrónico no existe. Comprueba la ortografía.",
+            "building_number_is_missing": "Falta el número de la vivienda.",
+            "building_number_not_found": "No se ha encontrado este número de la vivienda.",
+            "street_name_needs_correction": "La ortografía de la calle es incorrecta.",
+            "locality_needs_correction": "La ortografía de la localidad es incorrecta.",
+            "postal_code_needs_correction": "El código postal no es válido.",
+            "country_code_needs_correction": "La dirección introducida se ha encontrado en otro país.",
+            "phone_invalid": "El número de teléfono no es válido.",
+            "phone_format_needs_correction": "El número de teléfono tiene un formato incorrecto.",
+            "phone_should_be_fixed": "Introduce un número de teléfono fijo.",
+            "phone_should_be_mobile": "Introduce un número de teléfono móvil."
+        },
+        "errorMessages": {
+            "address_has_missing_building_number_content": "Falta el número de la vivienda en los datos introducidos.",
+            "address_has_unresolvable_building_number_content": "No se ha podido verificar la dirección con el número introducido.",
+            "packstation_has_unresolvable_address": "No se ha encontrado la dirección de Packstation.",
+            "postoffice_has_unresolvable_address": "No se ha encontrado la dirección de la oficina de correos.",
+            "packstation_has_unresolvable_postnummer": "El número postal no es válido."
+        },
+        "requiredFormat": {
+            "hintFormatE164": "Escribe el número en formato E.164, por ejemplo +4917678134170",
+            "hintFormatInternational": "Escribe el número en formato internacional, por ejemplo +49 176 78134170",
+            "hintFormatNational": "Escribe el número en formato nacional, por ejemplo 0176 78134170"
+        },
+        "inputFields": {
+            "enderedoStreetLabel": "Calle",
+            "enderedoStreetPlaceholder": "Introduce la calle ...",
+            "enderedoHousenumberLabel": "Número",
+            "enderedoHousenumberPlaceholder": "Introduce el número ..."
+        }
+    }
+}

--- a/src/Resources/snippet/fr_FR/storefront.fr-FR.json
+++ b/src/Resources/snippet/fr_FR/storefront.fr-FR.json
@@ -1,0 +1,55 @@
+{
+    "enderecoshopware6client": {
+        "texts": {
+            "popUpHeadline": "Vérifier l'adresse",
+            "popUpSubline": "L'adresse que vous avez saisie ne semble pas être correcte ou complète. Veuillez sélectionner l'adresse correcte.",
+            "yourInput": "Votre saisie :",
+            "editYourInput": "(modifier)",
+            "ourSuggestions": "Nos suggestions :",
+            "useSelected": "Appliquer la sélection",
+            "general_address": "Vérifier l'adresse",
+            "billing_address": "Vérifier l'adresse de facturation",
+            "shipping_address": "Vérifier l'adresse de livraison",
+            "mistakeNoPredictionSubline": "Votre adresse n'a pas pu être vérifiée. Veuillez vérifier votre saisie et la modifier ou la confirmer.",
+            "notFoundSubline": "Votre adresse n'a pas pu être vérifiée. Veuillez vérifier votre saisie et la modifier ou la confirmer.",
+            "confirmAddress": "Confirmer l'adresse",
+            "editAddress": "Modifier l'adresse",
+            "warningText": "Des adresses incorrectes peuvent entraîner des problèmes de livraison et générer des coûts supplémentaires.",
+            "confirmMyAddressCheckbox": "Je confirme que mon adresse est correcte et valide pour la livraison."
+        },
+        "statuses": {
+            "email_not_correct": "L'adresse e-mail ne semble pas être correcte",
+            "email_cant_receive": "La boîte e-mail n'est pas accessible",
+            "email_syntax_error": "Vérifiez l'orthographe",
+            "email_no_mx": "L'adresse e-mail n'existe pas. Vérifiez l'orthographe.",
+            "building_number_is_missing": "Le numéro de rue est manquant.",
+            "building_number_not_found": "Ce numéro de rue n'a pas été trouvé.",
+            "street_name_needs_correction": "L'orthographe de la rue est incorrecte.",
+            "locality_needs_correction": "L'orthographe de la localité est incorrecte.",
+            "postal_code_needs_correction": "Le code postal est invalide.",
+            "country_code_needs_correction": "L'adresse saisie a été trouvée dans un autre pays.",
+            "phone_invalid": "Le numéro de téléphone est invalide.",
+            "phone_format_needs_correction": "Le numéro de téléphone est mal formaté.",
+            "phone_should_be_fixed": "Veuillez saisir un numéro de téléphone fixe.",
+            "phone_should_be_mobile": "Veuillez saisir un numéro de téléphone mobile."
+        },
+        "errorMessages": {
+            "address_has_missing_building_number_content": "Le numéro de rue est manquant dans la saisie.",
+            "address_has_unresolvable_building_number_content": "L'adresse n'a pas pu être vérifiée avec le numéro de rue saisi.",
+            "packstation_has_unresolvable_address": "L'adresse de la Packstation n'a pas pu être trouvée.",
+            "postoffice_has_unresolvable_address": "L'adresse du bureau de poste n'a pas pu être trouvée.",
+            "packstation_has_unresolvable_postnummer": "Le numéro postal est invalide."
+        },
+        "requiredFormat": {
+            "hintFormatE164": "Veuillez écrire le numéro au format E.164, par ex. +4917678134170",
+            "hintFormatInternational": "Veuillez écrire le numéro au format international, par ex. +49 176 78134170",
+            "hintFormatNational": "Veuillez écrire le numéro au format national, par ex. 0176 78134170"
+        },
+        "inputFields": {
+            "enderedoStreetLabel": "Rue",
+            "enderedoStreetPlaceholder": "Saisissez la rue ...",
+            "enderedoHousenumberLabel": "Numéro",
+            "enderedoHousenumberPlaceholder": "Saisissez le numéro ..."
+        }
+    }
+}

--- a/src/Resources/snippet/it_IT/storefront.it-IT.json
+++ b/src/Resources/snippet/it_IT/storefront.it-IT.json
@@ -1,0 +1,55 @@
+{
+    "enderecoshopware6client": {
+        "texts": {
+            "popUpHeadline": "Verifica indirizzo",
+            "popUpSubline": "L'indirizzo inserito non sembra essere corretto o completo. Seleziona l'indirizzo corretto.",
+            "yourInput": "I dati inseriti:",
+            "editYourInput": "(modifica)",
+            "ourSuggestions": "I nostri suggerimenti:",
+            "useSelected": "Conferma la selezione",
+            "general_address": "Verifica indirizzo",
+            "billing_address": "Verifica indirizzo di fatturazione",
+            "shipping_address": "Verifica indirizzo di consegna",
+            "mistakeNoPredictionSubline": "Il tuo indirizzo non ha potuto essere verificato. Controlla i dati inseriti e modificali oppure confermali.",
+            "notFoundSubline": "Il tuo indirizzo non ha potuto essere verificato. Controlla i dati inseriti e modificali oppure confermali.",
+            "confirmAddress": "Conferma indirizzo",
+            "editAddress": "Modifica indirizzo",
+            "warningText": "Indirizzi errati possono causare problemi nella consegna e generare costi aggiuntivi.",
+            "confirmMyAddressCheckbox": "Confermo che il mio indirizzo è corretto e valido per la consegna."
+        },
+        "statuses": {
+            "email_not_correct": "L'indirizzo e-mail sembra non essere corretto",
+            "email_cant_receive": "La casella e-mail non è raggiungibile",
+            "email_syntax_error": "Controlla l'ortografia",
+            "email_no_mx": "L'indirizzo e-mail non esiste. Controlla l'ortografia.",
+            "building_number_is_missing": "Il numero civico non è indicato.",
+            "building_number_not_found": "Questo numero civico non è stato trovato.",
+            "street_name_needs_correction": "L'ortografia della via è errata.",
+            "locality_needs_correction": "L'ortografia della località è errata.",
+            "postal_code_needs_correction": "Il codice postale non è valido.",
+            "country_code_needs_correction": "L'indirizzo inserito è stato trovato in un altro Paese.",
+            "phone_invalid": "Il numero di telefono non è valido.",
+            "phone_format_needs_correction": "Il numero di telefono non è formattato correttamente.",
+            "phone_should_be_fixed": "Inserisci un numero di telefono fisso.",
+            "phone_should_be_mobile": "Inserisci un numero di telefono cellulare."
+        },
+        "errorMessages": {
+            "address_has_missing_building_number_content": "Il numero civico non è stato inserito.",
+            "address_has_unresolvable_building_number_content": "L'indirizzo non ha potuto essere verificato con il numero civico inserito.",
+            "packstation_has_unresolvable_address": "L'indirizzo della Packstation non è stato trovato.",
+            "postoffice_has_unresolvable_address": "L'indirizzo dell'ufficio postale non è stato trovato.",
+            "packstation_has_unresolvable_postnummer": "Il numero postale non è valido."
+        },
+        "requiredFormat": {
+            "hintFormatE164": "Scrivi il numero nel formato E.164, ad es. +4917678134170",
+            "hintFormatInternational": "Scrivi il numero nel formato internazionale, ad es. +49 176 78134170",
+            "hintFormatNational": "Scrivi il numero nel formato nazionale, ad es. 0176 78134170"
+        },
+        "inputFields": {
+            "enderedoStreetLabel": "Via",
+            "enderedoStreetPlaceholder": "Inserisci la via ...",
+            "enderedoHousenumberLabel": "Numero civico",
+            "enderedoHousenumberPlaceholder": "Inserisci il numero civico ..."
+        }
+    }
+}

--- a/src/Resources/snippet/nl_NL/storefront.nl-NL.json
+++ b/src/Resources/snippet/nl_NL/storefront.nl-NL.json
@@ -1,0 +1,55 @@
+{
+    "enderecoshopware6client": {
+        "texts": {
+            "popUpHeadline": "Adres controleren",
+            "popUpSubline": "Het door jou ingevoerde adres lijkt onjuist of onvolledig. Selecteer het juiste adres.",
+            "yourInput": "Jouw invoer:",
+            "editYourInput": "(bewerken)",
+            "ourSuggestions": "Onze suggesties:",
+            "useSelected": "Selectie bevestigen",
+            "general_address": "Adres controleren",
+            "billing_address": "Factuuradres controleren",
+            "shipping_address": "Afleveradres controleren",
+            "mistakeNoPredictionSubline": "Jouw adres kon niet worden geverifieerd. Controleer je invoer en pas deze aan of bevestig deze.",
+            "notFoundSubline": "Jouw adres kon niet worden geverifieerd. Controleer je invoer en pas deze aan of bevestig deze.",
+            "confirmAddress": "Adres bevestigen",
+            "editAddress": "Adres bewerken",
+            "warningText": "Onjuiste adressen kunnen leiden tot problemen bij de levering en extra kosten veroorzaken.",
+            "confirmMyAddressCheckbox": "Ik bevestig dat mijn adres correct is en geschikt voor bezorging."
+        },
+        "statuses": {
+            "email_not_correct": "Het e-mailadres lijkt niet correct te zijn",
+            "email_cant_receive": "De e-mailbox is niet bereikbaar",
+            "email_syntax_error": "Controleer de spelling",
+            "email_no_mx": "Het e-mailadres bestaat niet. Controleer de spelling.",
+            "building_number_is_missing": "Er is geen huisnummer ingevuld.",
+            "building_number_not_found": "Dit huisnummer is niet gevonden.",
+            "street_name_needs_correction": "De spelling van de straat is onjuist.",
+            "locality_needs_correction": "De spelling van de woonplaats is onjuist.",
+            "postal_code_needs_correction": "De postcode is ongeldig.",
+            "country_code_needs_correction": "Het ingevoerde adres is gevonden in een ander land.",
+            "phone_invalid": "Het telefoonnummer is ongeldig.",
+            "phone_format_needs_correction": "Het telefoonnummer heeft een onjuiste opmaak.",
+            "phone_should_be_fixed": "Voer een vast telefoonnummer in.",
+            "phone_should_be_mobile": "Voer een mobiel telefoonnummer in."
+        },
+        "errorMessages": {
+            "address_has_missing_building_number_content": "Het huisnummer ontbreekt in de invoer.",
+            "address_has_unresolvable_building_number_content": "Het adres kon niet worden geverifieerd met het ingevoerde huisnummer.",
+            "packstation_has_unresolvable_address": "Het Packstation-adres kon niet worden gevonden.",
+            "postoffice_has_unresolvable_address": "Het postkantooradres kon niet worden gevonden.",
+            "packstation_has_unresolvable_postnummer": "Het postnummer is ongeldig."
+        },
+        "requiredFormat": {
+            "hintFormatE164": "Schrijf het nummer in E.164-formaat, bijv. +4917678134170",
+            "hintFormatInternational": "Schrijf het nummer in internationaal formaat, bijv. +49 176 78134170",
+            "hintFormatNational": "Schrijf het nummer in nationaal formaat, bijv. 0176 78134170"
+        },
+        "inputFields": {
+            "enderedoStreetLabel": "Straat",
+            "enderedoStreetPlaceholder": "Straat invoeren ...",
+            "enderedoHousenumberLabel": "Huisnummer",
+            "enderedoHousenumberPlaceholder": "Huisnummer invoeren ..."
+        }
+    }
+}


### PR DESCRIPTION
Snippets for the Endereco Modal and error/status messages only existed in German and English. This commit adds translations of the snippets in Spanish, French, Italian and Dutch. Translations were made by Claude, and carefully crosschecked with ChatGPT, Gemini and the authors own language skills.

Ref: DEV-272