### PR TITLE
Replace HTML entities with UTF-8 characters in German snippets

### DIFF
--- a/check_mysql_compatibility.sh
+++ b/check_mysql_compatibility.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# MySQL version to check
+mysql_versions=("8.0" "8.1" "8.2" "8.3" "8.4")
+
+# Shopware version for dockware image
+shopware_version="6.6.10.6"
+
+# Plugin variables
+plugin_host_dir="./"  # Directory on host where your plugin files are stored
+plugin_container_dir="/var/www/html/custom/plugins/EnderecoShopware6Client"  # Directory in the container where plugins are stored
+
+base_container_name="check_mysql_compatibility"
+network_name="${base_container_name}_network"
+
+# Mysql variables
+mysql_container_name="${base_container_name}_mysql"
+mysql_user=shopware
+mysql_password=shopware
+mysql_database=shopware
+mysql_environment_variables="
+-e MYSQL_USER=${mysql_user}
+-e MYSQL_PASSWORD=${mysql_password}
+-e MYSQL_DATABASE=${mysql_database}
+-e MYSQL_RANDOM_ROOT_PASSWORD=yes
+"
+
+# Dockware variables
+dockware_container_name="${base_container_name}_dockware"
+dockware_image="dockware/dev:$shopware_version"
+dockware_environment_variables="
+-e DATABASE_URL=mysql://${mysql_user}:${mysql_password}@${mysql_container_name}/${mysql_database}
+"
+
+# Setup containers, copy plugin into dockware container, expects mysql version as first and only argument
+setup() {
+  # Create network for communication between dockware and mysql container, no port mappings required
+    docker network create $network_name
+
+    # Create mysql container with tmpfs and performance tuning
+    docker run \
+        -d \
+        $mysql_environment_variables \
+        --name $mysql_container_name \
+        --network=$network_name \
+        --tmpfs /var/lib/mysql:rw,size=2g \
+        --tmpfs /tmp:rw,size=512m \
+        --health-cmd="mysql -u $mysql_user -p$mysql_password -e 'SHOW TABLES;' $mysql_database > /dev/null || exit 1" \
+        --health-interval=5s \
+        --health-timeout=2s \
+        --health-retries=10 \
+        "mysql:$1" \
+        --innodb-flush-log-at-trx-commit=0 \
+        --innodb-buffer-pool-size=512M \
+        --innodb-log-file-size=256M \
+        --innodb-doublewrite=0 \
+        --sync-binlog=0 \
+        --skip-log-bin
+
+    # Wait until mysql container is healthy, fail when mysql container becomes unhealthy
+    until [ "$(docker inspect --format='{{json .State.Health.Status}}' "$mysql_container_name")" = "\"healthy\"" ]; do
+      health_status="$(docker inspect --format='{{json .State.Health.Status}}' "$mysql_container_name")"
+
+      if [ "$health_status" = "\"unhealthy\"" ]; then
+          echo "MySQL container health check failed (unhealthy)."
+          return 1
+      fi
+
+      echo "Waiting for MySQL container to become healthy..."
+      sleep 5
+    done
+
+    # Create dockware container with bind mounts for essential plugin files only
+    # Waiting for healthy not necessary, console is available right away
+    docker run \
+      -d \
+      $dockware_environment_variables \
+      --name $dockware_container_name \
+      --network=$network_name \
+      -v "$(pwd)/src:$plugin_container_dir/src" \
+      -v "$(pwd)/composer.json:$plugin_container_dir/composer.json" \
+      $dockware_image
+
+    # Install shopware in dockware container to run migrations in mysql container
+    # Needs --force to ignore the install.lock file
+    docker exec $dockware_container_name php bin/console system:install --force
+}
+
+# Checks mysql compatibility by installing the plugin
+run_mysql_compatibility_check() {
+  # Install and activate plugin via the console
+  docker exec $dockware_container_name php bin/console plugin:refresh
+  docker exec $dockware_container_name php bin/console plugin:install --activate EnderecoShopware6Client
+}
+
+# Stops and removes dockware and mysql container and the removes the network
+tear_down() {
+  docker stop $dockware_container_name
+  docker container rm $dockware_container_name
+  docker stop $mysql_container_name
+  docker container rm $mysql_container_name
+  docker network rm $network_name
+}
+
+for mysql_version in "${mysql_versions[@]}"; do
+  # setup containers
+  setup $mysql_version
+
+  # Run compatibility check
+  run_mysql_compatibility_check
+
+  # Check for failure, if so tear_down and exit
+  if [ $? -ne 0 ]; then
+    echo "compatibility check failed for mysql version $mysql_version"
+    tear_down
+    exit 1
+  fi
+
+  # Tear down after each MySQL version so that no running containers remain and the next check is restarted from scratch.
+  tear_down
+done

--- a/check_phpmd.sh
+++ b/check_phpmd.sh
@@ -2,16 +2,25 @@
 
 error_found=0
 
-files=$(find . -type d \( -path './vendor' -o -path './node_modules' -o -path './shops' \) -prune -o -type f -name '*.php' -print)
-
-for file in $files; do
-    echo "Checking $file"
-    output=$(vendor/bin/phpmd "$file" text unusedcode)
-    if [ -n "$output" ]; then
+# Check src directory if it exists
+if [ -d "src" ]; then
+    echo "Checking src directory"
+    output=$(vendor/bin/phpmd src text unusedcode)
+    if [ $? -ne 0 ] || [ -n "$output" ]; then
         echo "$output"
         error_found=1
     fi
-done
+fi
+
+# Check tests directory if it exists
+if [ -d "tests" ]; then
+    echo "Checking tests directory"
+    output=$(vendor/bin/phpmd tests text unusedcode)
+    if [ $? -ne 0 ] || [ -n "$output" ]; then
+        echo "$output"
+        error_found=1
+    fi
+fi
 
 # Check if any errors were found
 if [ $error_found -eq 1 ]; then

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "endereco/endereco-shopware6-client",
     "description": "Checks customers' addresses in real time. In case of errors, the customer is prompted to correct his address before sending via warning windows and error messages.",
-    "version": "6.6.2",
+    "version": "6.6.3",
     "type": "shopware-platform-plugin",
     "license": "AGPL-3.0-or-later",
     "authors": [

--- a/src/Migration/Migration1731623484CreateOrderAddressExtensionTable.php
+++ b/src/Migration/Migration1731623484CreateOrderAddressExtensionTable.php
@@ -16,29 +16,78 @@ class Migration1731623484CreateOrderAddressExtensionTable extends MigrationStep
     }
 
     /**
+     * @throws Exception
+     */
+    private function isGtMysql84(Connection $connection): bool
+    {
+        $isMariadb = (bool) $connection->executeQuery(<<<SQL
+        SELECT 
+            CASE
+                WHEN VERSION() LIKE '%MariaDB%' 
+                    OR @@version_comment LIKE '%MariaDB%' THEN 1
+                ELSE 0
+            END AS is_mariadb;
+        SQL)->fetchOne();
+
+        if ($isMariadb) {
+            return false;
+        }
+
+        $version = $connection->executeQuery(<<<SQL
+            SELECT VERSION()
+        SQL)->fetchOne();
+
+        return version_compare($version, '8.4', '>=');
+    }
+
+    /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @throws Exception
      */
     public function update(Connection $connection): void
     {
-        $sql = <<<SQL
-        CREATE TABLE IF NOT EXISTS `endereco_order_address_ext_gh` (
-            `address_id` BINARY(16) NOT NULL,
-            `ams_status` LONGTEXT NULL,
-            `ams_timestamp` INT NULL,
-            `ams_predictions` LONGTEXT NULL,
-            `is_amazon_pay_address` BOOLEAN NULL DEFAULT false,
-            `is_paypal_address` BOOLEAN NULL DEFAULT false,
-            `street` VARCHAR(255) NULL DEFAULT '',
-            `house_number` VARCHAR(255) NULL DEFAULT '',
-            `created_at` DATETIME(3) NOT NULL,
-            `updated_at` DATETIME(3) NULL,
-            PRIMARY KEY (`address_id`),
-            CONSTRAINT `fk.end_order_address_id_gh`
-                FOREIGN KEY (`address_id`) REFERENCES `order_address` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-        SQL;
+        if ($this->isGtMysql84($connection)) {
+            // Don't add order_address foreign key,
+            // added by Migration1753461221AddAddressIdColumnToOrderAddressExtensions.php
+            // because the migration won't run because of breaking changes in MySQL 8.4 in the default
+            // configuration
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS `endereco_order_address_ext_gh` (
+                `address_id` BINARY(16) NOT NULL,
+                `ams_status` LONGTEXT NULL,
+                `ams_timestamp` INT NULL,
+                `ams_predictions` LONGTEXT NULL,
+                `is_amazon_pay_address` BOOLEAN NULL DEFAULT false,
+                `is_paypal_address` BOOLEAN NULL DEFAULT false,
+                `street` VARCHAR(255) NULL DEFAULT '',
+                `house_number` VARCHAR(255) NULL DEFAULT '',
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`address_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL;
+        } else {
+            // in all cases where the migration already was executed nothing changes
+            // datamodels are adjusted in subsequent Migration1753461221AddAddressIDColumnToAdressExtensions.php
+            $sql = <<<SQL
+            CREATE TABLE IF NOT EXISTS `endereco_order_address_ext_gh` (
+                `address_id` BINARY(16) NOT NULL,
+                `ams_status` LONGTEXT NULL,
+                `ams_timestamp` INT NULL,
+                `ams_predictions` LONGTEXT NULL,
+                `is_amazon_pay_address` BOOLEAN NULL DEFAULT false,
+                `is_paypal_address` BOOLEAN NULL DEFAULT false,
+                `street` VARCHAR(255) NULL DEFAULT '',
+                `house_number` VARCHAR(255) NULL DEFAULT '',
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`address_id`),
+                CONSTRAINT `fk.end_order_address_id_gh`
+                    FOREIGN KEY (`address_id`) REFERENCES `order_address` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL;
+        }
         $connection->executeStatement($sql);
     }
 

--- a/src/Model/AddressCheckPayload.php
+++ b/src/Model/AddressCheckPayload.php
@@ -129,7 +129,7 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     {
         return json_encode($this->data(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
     }
-    
+
     /**
      * Returns the format type of this payload.
      *

--- a/src/Model/AddressCheckPayloadCombined.php
+++ b/src/Model/AddressCheckPayloadCombined.php
@@ -3,21 +3,13 @@
 namespace Endereco\Shopware6Client\Model;
 
 /**
- * Represents a structured payload for address validation requests to the Endereco API.
+ * Represents an address check payload using combined street format.
  *
- * This class encapsulates all necessary address components required for validation:
- * - Country code
- * - Postal/ZIP code
- * - City name
- * - Full street address
- * - Administrative subdivision code (state/province)
- *
- * The subdivision code has three possible states:
- * - null: The country has no states/subdivisions
- * - empty string: The country has states but none was selected
- * - string value: A specific state/subdivision was selected
+ * This class encapsulates address components where the street address
+ * is provided as a single field containing both street name and house number.
+ * This is the traditional format used by the plugin.
  */
-class AddressCheckPayload implements AddressCheckPayloadInterface
+class AddressCheckPayloadCombined implements AddressCheckPayloadInterface
 {
     /**
      * The country code (ISO format) for the address
@@ -48,21 +40,19 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     private ?string $subdivisionCode;
 
     /**
-     * Additional info found in on of the two possible fields in the address form.
-     *
-     * @var string|null
+     * Additional info found in one of the two possible fields in the address form.
      */
     private ?string $additionalInfo;
 
     /**
-     * Creates a new address check payload with all required components.
+     * Creates a new combined format address check payload.
      *
      * @param string $country The country code in ISO format
      * @param string $postCode The postal/ZIP code
      * @param string $cityName The city name
-     * @param string $streetFull The complete street address
+     * @param string $streetFull The complete street address including house number
      * @param string|null $subdivisionCode The state/province code or null/empty string based on availability
-     * @param string|null $additionalInfo The additional info sometimes provided in the formulars
+     * @param string|null $additionalInfo The additional info sometimes provided in the forms
      */
     public function __construct(
         string $country,
@@ -87,14 +77,7 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
      * allowing the API to distinguish between "no states exist" and "no state selected"
      * scenarios.
      *
-     * @return array{
-     *     country: string,
-     *     postCode: string,
-     *     cityName: string,
-     *     streetFull: string,
-     *     subdivisionCode?: string,
-     *     additionalInfo?: string
-     * } Array representation of the payload
+     * @return array<string, string> Array representation of the payload
      */
     public function data(): array
     {
@@ -129,14 +112,14 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     {
         return json_encode($this->data(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
     }
-    
+
     /**
      * Returns the format type of this payload.
      *
-     * @return string Always returns FORMAT_COMBINED for backward compatibility
+     * @return string Always returns FORMAT_COMBINED for this implementation
      */
     public function getFormatType(): string
     {
-        return self::FORMAT_COMBINED;
+        return AddressCheckPayloadInterface::FORMAT_COMBINED;
     }
 }

--- a/src/Model/AddressCheckPayloadInterface.php
+++ b/src/Model/AddressCheckPayloadInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Endereco\Shopware6Client\Model;
+
+/**
+ * Interface for address check payloads supporting different address formats.
+ *
+ * This interface defines the common contract for address payloads that can be
+ * used with the Endereco API, supporting both combined (traditional) and split
+ * (street name + house number) address formats.
+ */
+interface AddressCheckPayloadInterface
+{
+    /**
+     * Format type for combined street format (street name and house number in one field)
+     */
+    public const FORMAT_COMBINED = 'combined';
+
+    /**
+     * Format type for split street format (separate street name and house number fields)
+     */
+    public const FORMAT_SPLIT = 'split';
+    /**
+     * Converts the payload into an array format suitable for API submission.
+     *
+     * @return array<string, string> Array representation of the payload
+     */
+    public function data(): array;
+
+    /**
+     * Converts payload to JSON string with proper UTF-8 handling.
+     *
+     * @throws \JsonException On encoding failure
+     * @return string JSON representation of address data
+     */
+    public function toJSON(): string;
+
+    /**
+     * Returns the format type of this payload.
+     *
+     * @return string Either 'combined' for traditional street format or 'split' for separate street name/house number
+     */
+    public function getFormatType(): string;
+}

--- a/src/Model/AddressCheckPayloadSplit.php
+++ b/src/Model/AddressCheckPayloadSplit.php
@@ -3,21 +3,14 @@
 namespace Endereco\Shopware6Client\Model;
 
 /**
- * Represents a structured payload for address validation requests to the Endereco API.
+ * Represents an address check payload using split street format.
  *
- * This class encapsulates all necessary address components required for validation:
- * - Country code
- * - Postal/ZIP code
- * - City name
- * - Full street address
- * - Administrative subdivision code (state/province)
- *
- * The subdivision code has three possible states:
- * - null: The country has no states/subdivisions
- * - empty string: The country has states but none was selected
- * - string value: A specific state/subdivision was selected
+ * This class encapsulates address components where the street address
+ * is provided as separate fields for street name and house number.
+ * This format allows for more precise address validation and matches
+ * the API's native support for split address components.
  */
-class AddressCheckPayload implements AddressCheckPayloadInterface
+class AddressCheckPayloadSplit implements AddressCheckPayloadInterface
 {
     /**
      * The country code (ISO format) for the address
@@ -35,9 +28,14 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     private string $cityName;
 
     /**
-     * The complete street address including house number
+     * The street name without house number
      */
-    private string $streetFull;
+    private string $streetName;
+
+    /**
+     * The house number
+     */
+    private string $houseNumber;
 
     /**
      * The administrative subdivision (state/province) code
@@ -48,34 +46,35 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     private ?string $subdivisionCode;
 
     /**
-     * Additional info found in on of the two possible fields in the address form.
-     *
-     * @var string|null
+     * Additional info found in one of the two possible fields in the address form.
      */
     private ?string $additionalInfo;
 
     /**
-     * Creates a new address check payload with all required components.
+     * Creates a new split format address check payload.
      *
      * @param string $country The country code in ISO format
      * @param string $postCode The postal/ZIP code
      * @param string $cityName The city name
-     * @param string $streetFull The complete street address
+     * @param string $streetName The street name without house number
+     * @param string $houseNumber The house number
      * @param string|null $subdivisionCode The state/province code or null/empty string based on availability
-     * @param string|null $additionalInfo The additional info sometimes provided in the formulars
+     * @param string|null $additionalInfo The additional info sometimes provided in the forms
      */
     public function __construct(
         string $country,
         string $postCode,
         string $cityName,
-        string $streetFull,
+        string $streetName,
+        string $houseNumber,
         ?string $subdivisionCode,
         ?string $additionalInfo
     ) {
         $this->country = $country;
         $this->postCode = $postCode;
         $this->cityName = $cityName;
-        $this->streetFull = $streetFull;
+        $this->streetName = $streetName;
+        $this->houseNumber = $houseNumber;
         $this->subdivisionCode = $subdivisionCode;
         $this->additionalInfo = $additionalInfo;
     }
@@ -83,18 +82,10 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     /**
      * Converts the payload into an array format suitable for API submission.
      *
-     * The subdivision code is only included in the output if it's not null,
-     * allowing the API to distinguish between "no states exist" and "no state selected"
-     * scenarios.
+     * Uses separate 'street' and 'houseNumber' fields as per the API's split format support.
+     * The subdivision code is only included in the output if it's not null.
      *
-     * @return array{
-     *     country: string,
-     *     postCode: string,
-     *     cityName: string,
-     *     streetFull: string,
-     *     subdivisionCode?: string,
-     *     additionalInfo?: string
-     * } Array representation of the payload
+     * @return array<string, string> Array representation of the payload
      */
     public function data(): array
     {
@@ -102,7 +93,8 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
             'country' => $this->country,
             'postCode' => $this->postCode,
             'cityName' => $this->cityName,
-            'streetFull' => $this->streetFull,
+            'street' => $this->streetName,
+            'houseNumber' => $this->houseNumber,
         ];
 
         if ($this->subdivisionCode !== null) {
@@ -129,14 +121,14 @@ class AddressCheckPayload implements AddressCheckPayloadInterface
     {
         return json_encode($this->data(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
     }
-    
+
     /**
      * Returns the format type of this payload.
      *
-     * @return string Always returns FORMAT_COMBINED for backward compatibility
+     * @return string Always returns FORMAT_SPLIT for this implementation
      */
     public function getFormatType(): string
     {
-        return self::FORMAT_COMBINED;
+        return AddressCheckPayloadInterface::FORMAT_SPLIT;
     }
 }

--- a/src/Model/AddressCheckResult.php
+++ b/src/Model/AddressCheckResult.php
@@ -37,7 +37,7 @@ class AddressCheckResult
      * @var string A concatenated string of address fields used as fingerprint to detect address changes
      */
     protected $addressSignature = '';
-    
+
     /**
      * @var string The format type used when this result was generated (FORMAT_COMBINED or FORMAT_SPLIT)
      */
@@ -90,7 +90,7 @@ class AddressCheckResult
     {
         $this->addressSignature = $addressSignature;
     }
-    
+
     /**
      * @return string The format type used when this result was generated
      */

--- a/src/Model/AddressCheckResult.php
+++ b/src/Model/AddressCheckResult.php
@@ -37,6 +37,11 @@ class AddressCheckResult
      * @var string A concatenated string of address fields used as fingerprint to detect address changes
      */
     protected $addressSignature = '';
+    
+    /**
+     * @var string The format type used when this result was generated (FORMAT_COMBINED or FORMAT_SPLIT)
+     */
+    protected $formatType = AddressCheckPayloadInterface::FORMAT_COMBINED;
 
     /**
      * Checks if automatic correction has been applied.
@@ -84,6 +89,22 @@ class AddressCheckResult
     public function setAddressSignature(string $addressSignature): void
     {
         $this->addressSignature = $addressSignature;
+    }
+    
+    /**
+     * @return string The format type used when this result was generated
+     */
+    public function getFormatType(): string
+    {
+        return $this->formatType;
+    }
+
+    /**
+     * @param string $formatType The format type (FORMAT_COMBINED or FORMAT_SPLIT)
+     */
+    public function setFormatType(string $formatType): void
+    {
+        $this->formatType = $formatType;
     }
 
     /**

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -122,6 +122,192 @@
         <title>Billing and Shipping Address Check</title>
         <title lang="de-DE">Prüfung von Rechnungs- und Lieferadressen</title>
 
+        <input-field type="bool">
+            <name>enderecoAMSActive</name>
+            <label>Enable AMS (Address Check and Input Assistant)</label>
+            <label lang="de-DE">AMS aktivieren (Adressprüfung und Eingabe-Assistent)</label>
+            <defaultValue>true</defaultValue>
+            <helpText>
+                This is the master switch for endereco's Address Management System (AMS). When enabled, it activates both address validation and the input assistant features. Address validation checks entered addresses before form submission and prompts users to correct issues when found. The input assistant provides autocomplete functionality and optimizes field ordering for better user experience. Note: The Input Assistant setting below requires this to be enabled to function.
+            </helpText>
+            <helpText lang="de-DE">
+                Dies ist der Hauptschalter für endereco's Address Management System (AMS). Wenn aktiviert, werden sowohl die Adressvalidierung als auch die Eingabe-Assistent-Funktionen aktiviert. Die Adressvalidierung prüft eingegebene Adressen vor dem Absenden des Formulars und fordert Nutzer auf, Probleme zu korrigieren. Der Eingabe-Assistent bietet Autocomplete-Funktionen und optimiert die Feldreihenfolge für eine bessere Benutzererfahrung. Hinweis: Die Eingabe-Assistent-Einstellung unten benötigt diese Aktivierung, um zu funktionieren.</helpText>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoAddressInputAssistantActive</name>
+            <label>InputAssistant (Autocomplete) is active</label>
+            <label lang="de-DE">Eingabe-Assistent (Autocomplete) aktivieren</label>
+            <defaultValue>true</defaultValue>
+            <helpText>
+                If input-assistant is activated, then endereco will disable default browser autocomplete for the relevant fields, optimize (change) the field order for top-to-bottom address entry and display autocomplete dropdowns for address fields that can be autocompleted (zip code, locality, street at the moment). Note: Requires "Enable AMS" setting above to be activated.
+            </helpText>
+            <helpText lang="de-DE">
+                Wenn der Eingabe-Assistent aktiviert ist, deaktiviert endereco die Standard-Browser-Autovervollständigung für die relevanten Felder, optimiert (ändert) die Feldreihenfolge für die Adresseingabe und zeigt Autocomplete-Dropdowns für Adressfelder an, die automatisch vervollständigt werden können (derzeit Postleitzahl, Ort, Straße). Hinweis: Benötigt die Aktivierung der "AMS aktivieren" Einstellung oben.
+            </helpText>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoAllowCloseIcon</name>
+            <label>Allow closing the correction window</label>
+            <label lang="de-DE">Schließen der Korrekturhinweise erlauben</label>
+            <defaultValue>true</defaultValue>
+            <helpText>
+                If this function is active, a user can skip address suggestions of the address check without having
+                to make a selection.
+            </helpText>
+            <helpText lang="de-DE">
+                Ist diese Funktion aktiv, kann ein Nutzer Adressvorschläge der Adressprüfung übergehen ohne eine
+                Auswahl treffen zu müssen.
+            </helpText>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoConfirmWithCheckbox</name>
+            <label>Customer must confirm an incorrect address with a checkbox</label>
+            <label lang="de-DE">Kunde muss eine fehlerhafte Adresse mit einer Checkbox bestätigen</label>
+            <defaultValue>false</defaultValue>
+            <helpText>
+                If this function is active, the user must confirm his entered address if he does not want to accept an
+                address suggestion from Endereco.
+            </helpText>
+            <helpText lang="de-DE">
+                Ist diese Funktion aktiv, muss der Nutzer seine eingegebene Adresse bestätigen,
+                wenn er kein Adressvorschlag von Endereco übernehmen möchte.
+            </helpText>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoSplitStreetAndHouseNumber</name>
+            <label>Divide street into street name and house number</label>
+            <label lang="de-DE">Straße in Straßenname und Hausnummer unterteilen</label>
+            <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoCheckExistingAddress</name>
+            <label>Check addresses of existing customers once</label>
+            <label lang="de-DE">Adressen der Bestandskunden einmalig prüfen</label>
+            <helpText>
+                Invoice and delivery addresses of customers who had already registered before using the Endereco plugin
+                can be validated once with the existing customer check. These customers are shown a correction
+                suggestion if they want to place an order through their customer account and there is an error in the
+                address.
+            </helpText>
+            <helpText lang="de-DE">
+                Rechnungs- und Lieferadressen von Kunden, die bereits vor Nutzung des Endereco Plugins registriert
+                waren, können mit der Bestandskundenprüfung einmalig validiert werden. Diese Kunden bekommen einen
+                Korrekturvorschlag angezeigt, wenn sie über ihr Kundenkonto eine Bestellung tätigen möchten und ein
+                Fehler in der Adresse vorliegt.
+            </helpText>
+            <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoCheckPayPalExpressAddress</name>
+            <label>Check addresses via PayPal Express Checkout</label>
+            <label lang="de-DE">Adressen über PayPal Express Checkout prüfen</label>
+            <helpText>The PayPal Express check activates the validation of addresses for customers who place an order via PayPal Express. When returning from PayPal to the shop, a correction suggestion is displayed in case of an address error.</helpText>
+            <helpText lang="de-DE">Die PayPal Express Prüfung aktiviert die Validierung von Adressen für Kunden, die über PayPal Express eine Bestellung tätigen. Beim Rücksprung aus PayPal zum Shop wird bei einem Adressfehler ein Korrekturvorschlag angezeigt.</helpText>
+            <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoWriteOrderCustomFields</name>
+            <label>Write order billing and shipping address validation data to order `custom_fields`</label>
+            <label lang="de-DE">Validierungsdaten der Rechnungs- und Lieferadressen einer Bestellung in `custom_fields` schreiben</label>
+            <helpText>The billing and shipping address validation data are present in the address extensions. They can be written redundantly into `custom_fields` of the `Order` entity to simplify the access and processing.</helpText>
+            <helpText lang="de-DE">Die Validierungsdaten der Rechnungs- und Lieferadressen befinden sich in der Adresserweiterung. Sie können redundant in die `custom_fields` der `Order` Entität geschrieben werden um den Zugriff und die Verarbeitung zu vereinfachen.</helpText>
+            <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoImportExportCheck</name>
+            <label>Enable address checks during customer import</label>
+            <label lang="de-DE">Adressprüfung beim Kundenimport durchführen</label>
+            <defaultValue>false</defaultValue>
+            <helpText>
+                If enabled, Endereco will perform address checks on customer addresses during import operations. 
+                This can help ensure data quality but may slow down the import process.
+            </helpText>
+            <helpText lang="de-DE">
+                Wenn aktiviert, führt Endereco während des Importvorgangs Adressprüfungen für Kundenadressen durch. 
+                Dies kann die Datenqualität verbessern, könnte aber den Importvorgang verlangsamen.
+            </helpText>
+        </input-field>
+    </card>
+
+    <card>
+        <title>Phone Number Check</title>
+        <title lang="de-DE">Prüfung der Telefonnummer</title>
+
+        <input-field type="bool">
+            <name>enderecoPhsActive</name>
+            <label>Activate phone number check</label>
+            <label lang="de-DE">Rufnummernprüfung aktivieren</label>
+            <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="single-select">
+            <name>enderecoPhsUseFormat</name>
+            <options>
+                <option>
+                    <id>E164</id>
+                    <name>E.164 (+4912345678901)</name>
+                    <name lang="de-DE">E.164 (+4912345678901)</name>
+                </option>
+                <option>
+                    <id>INTERNATIONAL</id>
+                    <name>International (+49 1234 5678901)</name>
+                    <name lang="de-DE">International (+49 1234 5678901)</name>
+                </option>
+                <option>
+                    <id>NATIONAL</id>
+                    <name>National (01234 5678901)</name>
+                    <name lang="de-DE">National (01234 5678901)</name>
+                </option>
+                <option>
+                    <id>all</id>
+                    <name>Allow any</name>
+                    <name lang="de-DE">Alles zulassen</name>
+                </option>
+            </options>
+            <defaultValue>E164</defaultValue>
+            <label>Following format is expected</label>
+            <label lang="de-DE">Folgendes Format wird erwartet</label>
+        </input-field>
+
+        <input-field type="single-select">
+            <name>enderecoPhsDefaultFieldType</name>
+            <options>
+                <option>
+                    <id>general</id>
+                    <name>Mobile or fixed line number</name>
+                    <name lang="de-DE">Mobil- oder Festnetznummer</name>
+                </option>
+                <option>
+                    <id>mobile</id>
+                    <name>Only mobile number</name>
+                    <name lang="de-DE">Nur Mobilfunknummer</name>
+                </option>
+                <option>
+                    <id>fixedLine</id>
+                    <name>Only fixed line number</name>
+                    <name lang="de-DE">Nur Festnetznummer</name>
+                </option>
+            </options>
+            <defaultValue>general</defaultValue>
+            <label>Allowed phone number</label>
+            <label lang="de-DE">Erlaubte Telefonnummer</label>
+        </input-field>
+
+        <input-field type="bool">
+            <name>enderecoShowPhoneErrors</name>
+            <label>Display phone status messages</label>
+            <label lang="de-DE">Rufnummer Statusmeldungen anzeigen</label>
+            <defaultValue>true</defaultValue>
+        </input-field>
+
         <input-field type="single-select">
             <name>enderecoPreselectDefaultCountryCode</name>
             <options>
@@ -378,195 +564,8 @@
             <defaultValue>DE</defaultValue>
             <label>Default country</label>
             <label lang="de-DE">Standardland</label>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoAMSActive</name>
-            <label>Enable AMS (Address Check and Input Assistant)</label>
-            <label lang="de-DE">AMS aktivieren (Adressprüfung und Eingabe-Assistent)</label>
-            <defaultValue>true</defaultValue>
-            <helpText>
-                This is the master switch for endereco's Address Management System (AMS). When enabled, it activates both address validation and the input assistant features. Address validation checks entered addresses before form submission and prompts users to correct issues when found. The input assistant provides autocomplete functionality and optimizes field ordering for better user experience. Note: The Input Assistant setting below requires this to be enabled to function.
-            </helpText>
-            <helpText lang="de-DE">
-                Dies ist der Hauptschalter für endereco's Address Management System (AMS). Wenn aktiviert, werden sowohl die Adressvalidierung als auch die Eingabe-Assistent-Funktionen aktiviert. Die Adressvalidierung prüft eingegebene Adressen vor dem Absenden des Formulars und fordert Nutzer auf, Probleme zu korrigieren. Der Eingabe-Assistent bietet Autocomplete-Funktionen und optimiert die Feldreihenfolge für eine bessere Benutzererfahrung. Hinweis: Die Eingabe-Assistent-Einstellung unten benötigt diese Aktivierung, um zu funktionieren.</helpText>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoAddressInputAssistantActive</name>
-            <label>InputAssistant (Autocomplete) is active</label>
-            <label lang="de-DE">Eingabe-Assistent (Autocomplete) aktivieren</label>
-            <defaultValue>true</defaultValue>
-            <helpText>
-                If input-assistant is activated, then endereco will disable default browser autocomplete for the relevant fields, optimize (change) the field order for top-to-bottom address entry and display autocomplete dropdowns for address fields that can be autocompleted (zip code, locality, street at the moment). Note: Requires "Enable AMS" setting above to be activated.
-            </helpText>
-            <helpText lang="de-DE">
-                Wenn der Eingabe-Assistent aktiviert ist, deaktiviert endereco die Standard-Browser-Autovervollständigung für die relevanten Felder, optimiert (ändert) die Feldreihenfolge für die Adresseingabe und zeigt Autocomplete-Dropdowns für Adressfelder an, die automatisch vervollständigt werden können (derzeit Postleitzahl, Ort, Straße). Hinweis: Benötigt die Aktivierung der "AMS aktivieren" Einstellung oben.
-            </helpText>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoAllowCloseIcon</name>
-            <label>Allow closing the correction window</label>
-            <label lang="de-DE">Schließen der Korrekturhinweise erlauben</label>
-            <defaultValue>true</defaultValue>
-            <helpText>
-                If this function is active, a user can skip address suggestions of the address check without having
-                to make a selection.
-            </helpText>
-            <helpText lang="de-DE">
-                Ist diese Funktion aktiv, kann ein Nutzer Adressvorschläge der Adressprüfung übergehen ohne eine
-                Auswahl treffen zu müssen.
-            </helpText>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoConfirmWithCheckbox</name>
-            <label>Customer must confirm an incorrect address with a checkbox</label>
-            <label lang="de-DE">Kunde muss eine fehlerhafte Adresse mit einer Checkbox bestätigen</label>
-            <defaultValue>false</defaultValue>
-            <helpText>
-                If this function is active, the user must confirm his entered address if he does not want to accept an
-                address suggestion from Endereco.
-            </helpText>
-            <helpText lang="de-DE">
-                Ist diese Funktion aktiv, muss der Nutzer seine eingegebene Adresse bestätigen,
-                wenn er kein Adressvorschlag von Endereco übernehmen möchte.
-            </helpText>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoSplitStreetAndHouseNumber</name>
-            <label>Divide street into street name and house number</label>
-            <label lang="de-DE">Straße in Straßenname und Hausnummer unterteilen</label>
-            <defaultValue>false</defaultValue>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoCheckExistingAddress</name>
-            <label>Check addresses of existing customers once</label>
-            <label lang="de-DE">Adressen der Bestandskunden einmalig prüfen</label>
-            <helpText>
-                Invoice and delivery addresses of customers who had already registered before using the Endereco plugin
-                can be validated once with the existing customer check. These customers are shown a correction
-                suggestion if they want to place an order through their customer account and there is an error in the
-                address.
-            </helpText>
-            <helpText lang="de-DE">
-                Rechnungs- und Lieferadressen von Kunden, die bereits vor Nutzung des Endereco Plugins registriert
-                waren, können mit der Bestandskundenprüfung einmalig validiert werden. Diese Kunden bekommen einen
-                Korrekturvorschlag angezeigt, wenn sie über ihr Kundenkonto eine Bestellung tätigen möchten und ein
-                Fehler in der Adresse vorliegt.
-            </helpText>
-            <defaultValue>false</defaultValue>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoCheckPayPalExpressAddress</name>
-            <label>Check addresses via PayPal Express Checkout</label>
-            <label lang="de-DE">Adressen über PayPal Express Checkout prüfen</label>
-            <helpText>The PayPal Express check activates the validation of addresses for customers who place an order via PayPal Express. When returning from PayPal to the shop, a correction suggestion is displayed in case of an address error.</helpText>
-            <helpText lang="de-DE">Die PayPal Express Prüfung aktiviert die Validierung von Adressen für Kunden, die über PayPal Express eine Bestellung tätigen. Beim Rücksprung aus PayPal zum Shop wird bei einem Adressfehler ein Korrekturvorschlag angezeigt.</helpText>
-            <defaultValue>false</defaultValue>
-        </input-field>
-
-        <!-- TODO: Temporarily hidden due to order address handling bug - re-enable after tests pass -->
-        <!--
-        <input-field type="bool">
-            <name>enderecoWriteOrderCustomFields</name>
-            <label>Write order billing and shipping address validation data to order `custom_fields`</label>
-            <label lang="de-DE">Validierungsdaten der Rechnungs- und Lieferadressen einer Bestellung in `custom_fields` schreiben</label>
-            <helpText>The billing and shipping address validation data are present in the address extensions. They can be written redundantly into `custom_fields` of the `Order` entity to simplify the access and processing.</helpText>
-            <helpText lang="de-DE">Die Validierungsdaten der Rechnungs- und Lieferadressen befinden sich in der Adresserweiterung. Sie können redundant in die `custom_fields` der `Order` Entität geschrieben werden um den Zugriff und die Verarbeitung zu vereinfachen.</helpText>
-            <defaultValue>false</defaultValue>
-        </input-field>
-        -->
-
-        <input-field type="bool">
-            <name>enderecoImportExportCheck</name>
-            <label>Enable address checks during customer import</label>
-            <label lang="de-DE">Adressprüfung beim Kundenimport durchführen</label>
-            <defaultValue>false</defaultValue>
-            <helpText>
-                If enabled, Endereco will perform address checks on customer addresses during import operations. 
-                This can help ensure data quality but may slow down the import process.
-            </helpText>
-            <helpText lang="de-DE">
-                Wenn aktiviert, führt Endereco während des Importvorgangs Adressprüfungen für Kundenadressen durch. 
-                Dies kann die Datenqualität verbessern, könnte aber den Importvorgang verlangsamen.
-            </helpText>
-        </input-field>
-    </card>
-
-    <card>
-        <title>Phone Number Check</title>
-        <title lang="de-DE">Prüfung der Telefonnummer</title>
-
-        <input-field type="bool">
-            <name>enderecoPhsActive</name>
-            <label>Activate phone number check</label>
-            <label lang="de-DE">Rufnummernprüfung aktivieren</label>
-            <defaultValue>false</defaultValue>
-        </input-field>
-
-        <input-field type="single-select">
-            <name>enderecoPhsUseFormat</name>
-            <options>
-                <option>
-                    <id>E164</id>
-                    <name>E.164 (+4912345678901)</name>
-                    <name lang="de-DE">E.164 (+4912345678901)</name>
-                </option>
-                <option>
-                    <id>INTERNATIONAL</id>
-                    <name>International (+49 1234 5678901)</name>
-                    <name lang="de-DE">International (+49 1234 5678901)</name>
-                </option>
-                <option>
-                    <id>NATIONAL</id>
-                    <name>National (01234 5678901)</name>
-                    <name lang="de-DE">National (01234 5678901)</name>
-                </option>
-                <option>
-                    <id>all</id>
-                    <name>Allow any</name>
-                    <name lang="de-DE">Alles zulassen</name>
-                </option>
-            </options>
-            <defaultValue>E164</defaultValue>
-            <label>Following format is expected</label>
-            <label lang="de-DE">Folgendes Format wird erwartet</label>
-        </input-field>
-
-        <input-field type="single-select">
-            <name>enderecoPhsDefaultFieldType</name>
-            <options>
-                <option>
-                    <id>general</id>
-                    <name>Mobile or fixed line number</name>
-                    <name lang="de-DE">Mobil- oder Festnetznummer</name>
-                </option>
-                <option>
-                    <id>mobile</id>
-                    <name>Only mobile number</name>
-                    <name lang="de-DE">Nur Mobilfunknummer</name>
-                </option>
-                <option>
-                    <id>fixedLine</id>
-                    <name>Only fixed line number</name>
-                    <name lang="de-DE">Nur Festnetznummer</name>
-                </option>
-            </options>
-            <defaultValue>general</defaultValue>
-            <label>Allowed phone number</label>
-            <label lang="de-DE">Erlaubte Telefonnummer</label>
-        </input-field>
-
-        <input-field type="bool">
-            <name>enderecoShowPhoneErrors</name>
-            <label>Display phone status messages</label>
-            <label lang="de-DE">Rufnummer Statusmeldungen anzeigen</label>
-            <defaultValue>true</defaultValue>
+            <helpText>Default country used to interpret phone numbers entered in national format (without country code) when no country is selected in the frontend UI or is obvious from the entered number.</helpText>
+            <helpText lang="de-DE">Standardland zur Interpretation von Telefonnummern im nationalen Format (ohne Ländercode), wenn kein Land in der Benutzeroberfläche ausgewählt ist oder das Land nicht automatisch aus der Nummerstruktur ermittelt werden kann.</helpText>
         </input-field>
     </card>
 

--- a/src/Resources/config/services/service_address_check.php
+++ b/src/Resources/config/services/service_address_check.php
@@ -23,6 +23,8 @@ use Endereco\Shopware6Client\Service\AddressCheck\SubdivisionCodeFetcher;
 use Endereco\Shopware6Client\Service\AddressCheck\SubdivisionCodeFetcherInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\PayloadPreparatorInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\RequestHeadersGeneratorInterface;
+use Endereco\Shopware6Client\Service\AddressCorrection\StreetSplitterInterface;
+use Endereco\Shopware6Client\Service\EnderecoService;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -60,6 +62,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$subdivisionCodeFetcher' => service(SubdivisionCodeFetcherInterface::class),
             '$countryHasStatesChecker' => service(CountryHasStatesCheckerInterface::class),
             '$additionalAddressFieldChecker' => service(AdditionalAddressFieldCheckerInterface::class),
+            '$systemConfigService' => service(SystemConfigService::class),
+            '$streetSplitter' => service(StreetSplitterInterface::class),
+            '$customerAddressExtensionRepository' => service('endereco_customer_address_ext_gh.repository'),
+            '$orderAddressExtensionRepository' => service('endereco_order_address_ext_gh.repository'),
+            '$enderecoService' => service(EnderecoService::class),
         ]);
     $services->alias(AddressCheckPayloadBuilderInterface::class, AddressCheckPayloadBuilder::class);
 

--- a/src/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Resources/snippet/de_DE/storefront.de-DE.json
@@ -2,7 +2,7 @@
     "enderecoshopware6client": {
         "texts": {
             "popUpHeadline": "Adresse prüfen",
-            "popUpSubline": "Die von Ihnen eingegebene Adresse scheint nicht korrekt oder unvollst&auml;ndig zu sein. Bitte w&auml;hlen Sie die korrekte Adresse aus.",
+            "popUpSubline": "Die von Ihnen eingegebene Adresse scheint nicht korrekt oder unvollständig zu sein. Bitte wählen Sie die korrekte Adresse aus.",
             "yourInput": "Ihre Eingabe:",
             "editYourInput": "(bearbeiten)",
             "ourSuggestions": "Unsere Vorschläge:",

--- a/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
+++ b/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
@@ -3,10 +3,25 @@
 namespace Endereco\Shopware6Client\Service\AddressCheck;
 
 use Endereco\Shopware6Client\Model\AddressCheckPayload;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadInterface;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadCombined;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadSplit;
+use Endereco\Shopware6Client\Service\AddressCorrection\StreetSplitterInterface;
+use Endereco\Shopware6Client\Service\EnderecoService;
+use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
+use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionCollection;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionCollection;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
 use Endereco\Shopware6Client\Model\AddressCheckData;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
  * Implements building address check payloads for the Endereco API.
@@ -46,6 +61,33 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
     private AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker;
 
     /**
+     * Service for accessing system configuration
+     */
+    private SystemConfigService $systemConfigService;
+
+    /**
+     * Service for splitting street addresses
+     */
+    private StreetSplitterInterface $streetSplitter;
+
+    /**
+     * Repository for customer address extensions
+     * @var EntityRepository<EnderecoCustomerAddressExtensionCollection>
+     */
+    private EntityRepository $customerAddressExtensionRepository;
+
+    /**
+     * Repository for order address extensions
+     * @var EntityRepository<EnderecoOrderAddressExtensionCollection>
+     */
+    private EntityRepository $orderAddressExtensionRepository;
+
+    /**
+     * Service for getting sales channel ID from context
+     */
+    private EnderecoService $enderecoService;
+    
+    /**
      * Creates a new AddressCheckPayloadBuilder with required dependencies.
      *
      * @param CountryCodeFetcherInterface $countryCodeFetcher Service for country code lookup
@@ -53,47 +95,46 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
      * @param CountryHasStatesCheckerInterface $countryHasStatesChecker Service for checking country subdivision support
      * @param AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker Checks if additional info is present
      */
+    /**
+     * @param EntityRepository<EnderecoCustomerAddressExtensionCollection> $customerAddressExtensionRepository
+     * @param EntityRepository<EnderecoOrderAddressExtensionCollection> $orderAddressExtensionRepository
+     */
     public function __construct(
         CountryCodeFetcherInterface $countryCodeFetcher,
         SubdivisionCodeFetcherInterface $subdivisionCodeFetcher,
         CountryHasStatesCheckerInterface $countryHasStatesChecker,
-        AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker
+        AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker,
+        SystemConfigService $systemConfigService,
+        StreetSplitterInterface $streetSplitter,
+        EntityRepository $customerAddressExtensionRepository,
+        EntityRepository $orderAddressExtensionRepository,
+        EnderecoService $enderecoService
     ) {
         $this->countryCodeFetcher = $countryCodeFetcher;
         $this->subdivisionCodeFetcher = $subdivisionCodeFetcher;
         $this->countryHasStatesChecker = $countryHasStatesChecker;
         $this->additionalAddressFieldChecker = $additionalAddressFieldChecker;
+        $this->systemConfigService = $systemConfigService;
+        $this->streetSplitter = $streetSplitter;
+        $this->customerAddressExtensionRepository = $customerAddressExtensionRepository;
+        $this->orderAddressExtensionRepository = $orderAddressExtensionRepository;
+        $this->enderecoService = $enderecoService;
     }
 
     /**
      * @param AddressDataStructure $addressData Address data to transform
      * @param Context $context Shopware context
-     * @return AddressCheckPayload Payload (not ready for API)
+     * @return AddressCheckPayloadInterface Payload (not ready for API)
      */
     public function buildFromArray(
         array $addressData,
         Context $context
-    ): AddressCheckPayload {
-        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
-            $addressData['countryId'],
-            $context
-        );
-
-        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressData, $context);
-
-        $additionalInfo = null;
-        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
-            $additionalInfo = $this->getAdditionalInfoFromArray($addressData, $context);
+    ): AddressCheckPayloadInterface {
+        if ($this->shouldUseSplitFormat($context)) {
+            return $this->buildSplitPayload($addressData, $context);
         }
-
-        return new AddressCheckPayload(
-            $countryCode,
-            $addressData['zipcode'],
-            $addressData['city'],
-            $addressData['street'],
-            $subdivisionCode,
-            $additionalInfo
-        );
+        
+        return $this->buildCombinedPayload($addressData, $context);
     }
 
     /**
@@ -106,19 +147,12 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
     public function buildFromCustomerAddress(
         CustomerAddressEntity $address,
         Context $context
-    ): AddressCheckPayload {
-        return $this->buildFromArray(
-            [
-                'countryId' => $address->getCountryId(),
-                'countryStateId' => $address->getCountryStateId(),
-                'zipcode' => $address->getZipcode() ?? '', // we dont support no zip code yet
-                'city' => $address->getCity(),
-                'street' => $address->getStreet(),
-                'additionalAddressLine1' => $address->getAdditionalAddressLine1(),
-                'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
-            ],
-            $context
-        );
+    ): AddressCheckPayloadInterface {
+        if ($this->shouldUseSplitFormat($context)) {
+            return $this->buildSplitPayloadFromCustomerAddress($address, $context);
+        }
+        
+        return $this->buildCombinedPayloadFromCustomerAddress($address, $context);
     }
 
     /**
@@ -126,24 +160,17 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
      *
      * @param OrderAddressEntity $address Order address entity
      * @param Context $context Shopware context
-     * @return AddressCheckPayload Payload (not ready for API)
+     * @return AddressCheckPayloadInterface Payload (not ready for API)
      */
     public function buildFromOrderAddress(
         OrderAddressEntity $address,
         Context $context
-    ): AddressCheckPayload {
-        return $this->buildFromArray(
-            [
-                'countryId' => $address->getCountryId(),
-                'countryStateId' => $address->getCountryStateId(),
-                'zipcode' => $address->getZipcode() ?? '', // we dont support no zip code yet
-                'city' => $address->getCity(),
-                'street' => $address->getStreet(),
-                'additionalAddressLine1' => $address->getAdditionalAddressLine1(),
-                'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
-            ],
-            $context
-        );
+    ): AddressCheckPayloadInterface {
+        if ($this->shouldUseSplitFormat($context)) {
+            return $this->buildSplitPayloadFromOrderAddress($address, $context);
+        }
+        
+        return $this->buildCombinedPayloadFromOrderAddress($address, $context);
     }
 
     /**
@@ -184,5 +211,472 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
     {
         $fieldName = $this->additionalAddressFieldChecker->getAvailableAdditionalAddressFieldName($context);
         return $addressData[$fieldName] ?? '';
+    }
+    
+    /**
+     * Determines whether to use split address format based on system configuration.
+     *
+     * @param Context $context Shopware context
+     * @return bool True if split format should be used, false for combined format
+     */
+    private function shouldUseSplitFormat(Context $context): bool
+    {
+        // Get the sales channel ID from context (if available)
+        $salesChannelId = null;
+        $source = $context->getSource();
+        if ($source instanceof \Shopware\Core\Framework\Api\Context\SalesChannelApiSource) {
+            $salesChannelId = $source->getSalesChannelId();
+        }
+
+        return $this->systemConfigService->getBool(
+            AddressCheckPayloadBuilderInterface::CONFIG_SPLIT_STREET,
+            $salesChannelId
+        );
+    }
+
+    /**
+     * Extracts split address data from CustomerAddressEntity's Endereco extension.
+     *
+     * @param CustomerAddressEntity $address Customer address entity
+     * @param Context $context Shopware context
+     * @return array{streetName: string, houseNumber: string}|null Split address data or null if not available
+     */
+    protected function extractSplitAddressFromCustomerAddress(CustomerAddressEntity $address, Context $context): ?array
+    {
+        $extension = $address->getExtension(CustomerAddressExtension::ENDERECO_EXTENSION);
+        
+        // If extension is not loaded, try to load it from database
+        if (!$extension instanceof EnderecoCustomerAddressExtensionEntity) {
+            $extension = $this->loadCustomerAddressExtension($address->getId(), $context);
+        }
+        
+        if (!$extension instanceof EnderecoCustomerAddressExtensionEntity) {
+            return null;
+        }
+
+        $streetName = $extension->getStreet();
+        $houseNumber = $extension->getHouseNumber();
+
+        // Only return if we have at least the street name
+        if (empty($streetName)) {
+            return null;
+        }
+
+        return [
+            'streetName' => $streetName,
+            'houseNumber' => $houseNumber
+        ];
+    }
+
+    /**
+     * Extracts split address data from OrderAddressEntity's Endereco extension.
+     *
+     * @param OrderAddressEntity $address Order address entity
+     * @param Context $context Shopware context
+     * @return array{streetName: string, houseNumber: string}|null Split address data or null if not available
+     */
+    protected function extractSplitAddressFromOrderAddress(OrderAddressEntity $address, Context $context): ?array
+    {
+        $extension = $address->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
+        
+        // If extension is not loaded, try to load it from database
+        if (!$extension instanceof EnderecoOrderAddressExtensionEntity) {
+            $versionId = $address->getVersionId();
+            if ($versionId !== null) {
+                $extension = $this->loadOrderAddressExtension($address->getId(), $versionId, $context);
+            }
+        }
+        
+        if (!$extension instanceof EnderecoOrderAddressExtensionEntity) {
+            return null;
+        }
+
+        $streetName = $extension->getStreet();
+        $houseNumber = $extension->getHouseNumber();
+
+        // Only return if we have at least the street name
+        if (empty($streetName)) {
+            return null;
+        }
+
+        return [
+            'streetName' => $streetName,
+            'houseNumber' => $houseNumber
+        ];
+    }
+
+    /**
+     * Extracts split address data from array input (e.g., from frontend).
+     * 
+     * Checks for various possible field names that might contain split address data.
+     *
+     * @param array<string, mixed> $addressData Address data array
+     * @return array{streetName: string, houseNumber: string}|null Split address data or null if not available
+     */
+    protected function extractSplitAddressFromArray(array $addressData): ?array
+    {
+        // Check for Endereco street splitting fields used in the frontend
+        $streetName = $addressData['enderecoStreet'] ?? '';
+        $houseNumber = $addressData['enderecoHousenumber'] ?? '';
+
+        // Only return if we have at least the street name
+        if (empty($streetName)) {
+            return null;
+        }
+
+        return [
+            'streetName' => (string) $streetName,
+            'houseNumber' => (string) $houseNumber
+        ];
+    }
+
+    /**
+     * Builds a combined payload from array data.
+     *
+     * @param array<string, mixed> $addressData Address data array
+     * @param Context $context Shopware context
+     * @return AddressCheckPayloadCombined
+     */
+    private function buildCombinedPayload(array $addressData, Context $context): AddressCheckPayloadCombined
+    {
+        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
+            $addressData['countryId'],
+            $context
+        );
+
+        $addressDataStructure = [
+            'countryId' => (string) $addressData['countryId'],
+            'countryStateId' => $addressData['countryStateId'] ?? null,
+            'zipcode' => (string) $addressData['zipcode'],
+            'city' => (string) $addressData['city'],
+            'street' => (string) $addressData['street'],
+            'additionalAddressLine1' => $addressData['additionalAddressLine1'] ?? null,
+            'additionalAddressLine2' => $addressData['additionalAddressLine2'] ?? null,
+        ];
+
+        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressDataStructure, $context);
+
+        $additionalInfo = null;
+        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
+            $additionalInfo = $this->getAdditionalInfoFromArray($addressDataStructure, $context);
+        }
+
+        return new AddressCheckPayloadCombined(
+            $countryCode,
+            $addressData['zipcode'],
+            $addressData['city'],
+            $addressData['street'],
+            $subdivisionCode,
+            $additionalInfo
+        );
+    }
+
+    /**
+     * Builds a split payload from array data.
+     *
+     * @param array<string, mixed> $addressData Address data array
+     * @param Context $context Shopware context
+     * @return AddressCheckPayloadSplit
+     */
+    private function buildSplitPayload(array $addressData, Context $context): AddressCheckPayloadSplit
+    {
+        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
+            $addressData['countryId'],
+            $context
+        );
+
+        $addressDataStructure = [
+            'countryId' => (string) $addressData['countryId'],
+            'countryStateId' => $addressData['countryStateId'] ?? null,
+            'zipcode' => (string) $addressData['zipcode'],
+            'city' => (string) $addressData['city'],
+            'street' => (string) $addressData['street'],
+            'additionalAddressLine1' => $addressData['additionalAddressLine1'] ?? null,
+            'additionalAddressLine2' => $addressData['additionalAddressLine2'] ?? null,
+        ];
+
+        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressDataStructure, $context);
+
+        $additionalInfo = null;
+        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
+            $additionalInfo = $this->getAdditionalInfoFromArray($addressDataStructure, $context);
+        }
+
+        // We might have the data already from the frontend.
+        $splitData = $this->extractSplitAddressFromArray($addressData);
+
+        if ($splitData === null) {
+            // Need to split using API
+            $splitResult = $this->streetSplitter->splitStreet(
+                $addressData['street'],
+                $additionalInfo,
+                $countryCode,
+                $context,
+                $this->enderecoService->fetchSalesChannelId($context)
+            );
+            $streetName = $splitResult->getStreetName();
+            $buildingNumber = $splitResult->getBuildingNumber();
+            $additionalInfo = $splitResult->getAdditionalInfo();
+        } else {
+            $streetName = $splitData['streetName'];
+            $buildingNumber = $splitData['houseNumber'];
+        }
+
+        return new AddressCheckPayloadSplit(
+            $countryCode,
+            $addressData['zipcode'],
+            $addressData['city'],
+            $streetName,
+            $buildingNumber,
+            $subdivisionCode,
+            $additionalInfo
+        );
+    }
+
+    /**
+     * Builds a combined payload from CustomerAddressEntity.
+     *
+     * @param CustomerAddressEntity $address Customer address entity
+     * @param Context $context Shopware context
+     * @return AddressCheckPayloadCombined
+     */
+    private function buildCombinedPayloadFromCustomerAddress(CustomerAddressEntity $address, Context $context): AddressCheckPayloadCombined
+    {
+        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
+            $address->getCountryId(),
+            $context
+        );
+
+        $addressDataStructure = [
+            'countryId' => $address->getCountryId(),
+            'countryStateId' => $address->getCountryStateId(),
+            'zipcode' => $address->getZipcode() ?? '',
+            'city' => $address->getCity(),
+            'street' => $address->getStreet(),
+            'additionalAddressLine1' => $address->getAdditionalAddressLine1(),
+            'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
+        ];
+
+        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressDataStructure, $context);
+
+        $additionalInfo = null;
+        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
+            $additionalInfo = $this->getAdditionalInfoFromArray($addressDataStructure, $context);
+        }
+
+        return new AddressCheckPayloadCombined(
+            $countryCode,
+            $address->getZipcode() ?? '',
+            $address->getCity(),
+            $address->getStreet(),
+            $subdivisionCode,
+            $additionalInfo
+        );
+    }
+
+    /**
+     * Builds a split payload from CustomerAddressEntity.
+     *
+     * @param CustomerAddressEntity $address Customer address entity
+     * @param Context $context Shopware context
+     * @return AddressCheckPayloadSplit
+     */
+    private function buildSplitPayloadFromCustomerAddress(CustomerAddressEntity $address, Context $context): AddressCheckPayloadSplit
+    {
+        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
+            $address->getCountryId(),
+            $context
+        );
+
+        $addressDataStructure = [
+            'countryId' => $address->getCountryId(),
+            'countryStateId' => $address->getCountryStateId(),
+            'zipcode' => $address->getZipcode() ?? '',
+            'city' => $address->getCity(),
+            'street' => $address->getStreet(),
+            'additionalAddressLine1' => $address->getAdditionalAddressLine1(),
+            'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
+        ];
+
+        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressDataStructure, $context);
+
+        $additionalInfo = null;
+        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
+            $additionalInfo = $this->getAdditionalInfoFromArray($addressDataStructure, $context);
+        }
+
+        // We might have the data already from the extension.
+        $splitData = $this->extractSplitAddressFromCustomerAddress($address, $context);
+
+        if ($splitData === null) {
+            // Need to split using API
+            $splitResult = $this->streetSplitter->splitStreet(
+                $address->getStreet(),
+                $additionalInfo,
+                $countryCode,
+                $context,
+                $this->enderecoService->fetchSalesChannelId($context)
+            );
+            $streetName = $splitResult->getStreetName();
+            $buildingNumber = $splitResult->getBuildingNumber();
+            $additionalInfo = $splitResult->getAdditionalInfo();
+        } else {
+            $streetName = $splitData['streetName'];
+            $buildingNumber = $splitData['houseNumber'];
+        }
+
+        return new AddressCheckPayloadSplit(
+            $countryCode,
+            $address->getZipcode() ?? '',
+            $address->getCity(),
+            $streetName,
+            $buildingNumber,
+            $subdivisionCode,
+            $additionalInfo
+        );
+    }
+
+    /**
+     * Builds a combined payload from OrderAddressEntity.
+     *
+     * @param OrderAddressEntity $address Order address entity
+     * @param Context $context Shopware context
+     * @return AddressCheckPayloadCombined
+     */
+    private function buildCombinedPayloadFromOrderAddress(OrderAddressEntity $address, Context $context): AddressCheckPayloadCombined
+    {
+        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
+            $address->getCountryId(),
+            $context
+        );
+
+        $addressDataStructure = [
+            'countryId' => $address->getCountryId(),
+            'countryStateId' => $address->getCountryStateId(),
+            'zipcode' => $address->getZipcode() ?? '',
+            'city' => $address->getCity(),
+            'street' => $address->getStreet(),
+            'additionalAddressLine1' => $address->getAdditionalAddressLine1(),
+            'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
+        ];
+
+        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressDataStructure, $context);
+
+        $additionalInfo = null;
+        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
+            $additionalInfo = $this->getAdditionalInfoFromArray($addressDataStructure, $context);
+        }
+
+        return new AddressCheckPayloadCombined(
+            $countryCode,
+            $address->getZipcode() ?? '',
+            $address->getCity(),
+            $address->getStreet(),
+            $subdivisionCode,
+            $additionalInfo
+        );
+    }
+
+    /**
+     * Builds a split payload from OrderAddressEntity.
+     *
+     * @param OrderAddressEntity $address Order address entity
+     * @param Context $context Shopware context
+     * @return AddressCheckPayloadSplit
+     */
+    private function buildSplitPayloadFromOrderAddress(OrderAddressEntity $address, Context $context): AddressCheckPayloadSplit
+    {
+        $countryCode = $this->countryCodeFetcher->fetchCountryCodeByCountryIdAndContext(
+            $address->getCountryId(),
+            $context
+        );
+
+        $addressDataStructure = [
+            'countryId' => $address->getCountryId(),
+            'countryStateId' => $address->getCountryStateId(),
+            'zipcode' => $address->getZipcode() ?? '',
+            'city' => $address->getCity(),
+            'street' => $address->getStreet(),
+            'additionalAddressLine1' => $address->getAdditionalAddressLine1(),
+            'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
+        ];
+
+        $subdivisionCode = $this->getSubdivisionCodeFromArray($addressDataStructure, $context);
+
+        $additionalInfo = null;
+        if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($context)) {
+            $additionalInfo = $this->getAdditionalInfoFromArray($addressDataStructure, $context);
+        }
+
+        // We might have the data already from the extension.
+        $splitData = $this->extractSplitAddressFromOrderAddress($address, $context);
+
+        if ($splitData === null) {
+            // Need to split using API
+            $splitResult = $this->streetSplitter->splitStreet(
+                $address->getStreet(),
+                $additionalInfo,
+                $countryCode,
+                $context,
+                $this->enderecoService->fetchSalesChannelId($context)
+            );
+            $streetName = $splitResult->getStreetName();
+            $buildingNumber = $splitResult->getBuildingNumber();
+            $additionalInfo = $splitResult->getAdditionalInfo();
+        } else {
+            $streetName = $splitData['streetName'];
+            $buildingNumber = $splitData['houseNumber'];
+        }
+
+        return new AddressCheckPayloadSplit(
+            $countryCode,
+            $address->getZipcode() ?? '',
+            $address->getCity(),
+            $streetName,
+            $buildingNumber,
+            $subdivisionCode,
+            $additionalInfo
+        );
+    }
+
+    /**
+     * Loads customer address extension from database if not already loaded.
+     *
+     * @param string $customerAddressId Customer address ID
+     * @param Context $context Shopware context
+     * @return EnderecoCustomerAddressExtensionEntity|null Extension entity or null if not found
+     */
+    private function loadCustomerAddressExtension(string $customerAddressId, Context $context): ?EnderecoCustomerAddressExtensionEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('addressId', $customerAddressId));
+        
+        $result = $this->customerAddressExtensionRepository->search($criteria, $context);
+        
+        $entity = $result->first();
+        return $entity instanceof EnderecoCustomerAddressExtensionEntity ? $entity : null;
+    }
+
+    /**
+     * Loads order address extension from database if not already loaded.
+     * 
+     * Order addresses are versioned entities, so we need to match both
+     * the address ID and version ID for precise identification.
+     *
+     * @param string $orderAddressId Order address ID
+     * @param string $orderAddressVersionId Order address version ID
+     * @param Context $context Shopware context
+     * @return EnderecoOrderAddressExtensionEntity|null Extension entity or null if not found
+     */
+    private function loadOrderAddressExtension(string $orderAddressId, string $orderAddressVersionId, Context $context): ?EnderecoOrderAddressExtensionEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('addressId', $orderAddressId));
+        $criteria->addFilter(new EqualsFilter('addressVersionId', $orderAddressVersionId));
+        
+        $result = $this->orderAddressExtensionRepository->search($criteria, $context);
+        
+        $entity = $result->first();
+        return $entity instanceof EnderecoOrderAddressExtensionEntity ? $entity : null;
     }
 }

--- a/src/Service/AddressCheck/AddressCheckPayloadBuilderInterface.php
+++ b/src/Service/AddressCheck/AddressCheckPayloadBuilderInterface.php
@@ -3,12 +3,17 @@
 namespace Endereco\Shopware6Client\Service\AddressCheck;
 
 use Endereco\Shopware6Client\Model\AddressCheckPayload;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadInterface;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Framework\Context;
 
 interface AddressCheckPayloadBuilderInterface
 {
+    /**
+     * System configuration key for split street format setting
+     */
+    public const CONFIG_SPLIT_STREET = 'EnderecoShopware6Client.config.enderecoSplitStreetAndHouseNumber';
     /**
      * Builds payload from array data (e.g. from POST request)
      *
@@ -22,25 +27,25 @@ interface AddressCheckPayloadBuilderInterface
      *   additionalAddressLine2: string|null
      * } $addressData
      * @param Context $context
-     * @return AddressCheckPayload
+     * @return AddressCheckPayloadInterface
      */
-    public function buildFromArray(array $addressData, Context $context): AddressCheckPayload;
+    public function buildFromArray(array $addressData, Context $context): AddressCheckPayloadInterface;
 
     /**
      * Builds payload from CustomerAddressEntity
      *
      * @param CustomerAddressEntity $address
      * @param Context $context
-     * @return AddressCheckPayload
+     * @return AddressCheckPayloadInterface
      */
-    public function buildFromCustomerAddress(CustomerAddressEntity $address, Context $context): AddressCheckPayload;
+    public function buildFromCustomerAddress(CustomerAddressEntity $address, Context $context): AddressCheckPayloadInterface;
 
     /**
      * Builds payload from OrderAddressEntity
      *
      * @param OrderAddressEntity $address
      * @param Context $context
-     * @return AddressCheckPayload
+     * @return AddressCheckPayloadInterface
      */
-    public function buildFromOrderAddress(OrderAddressEntity $address, Context $context): AddressCheckPayload;
+    public function buildFromOrderAddress(OrderAddressEntity $address, Context $context): AddressCheckPayloadInterface;
 }

--- a/src/Service/AddressCheck/AddressChecker.php
+++ b/src/Service/AddressCheck/AddressChecker.php
@@ -124,6 +124,7 @@ final class AddressChecker implements AddressCheckerInterface
 
         $addressCheckResult->setUsedSessionId($sessionId);
         $addressCheckResult->setAddressSignature($payloadBody->toJSON());
+        $addressCheckResult->setFormatType($payloadBody->getFormatType());
 
         return $addressCheckResult;
     }

--- a/src/Service/AddressCheck/AddressCheckerWithCache.php
+++ b/src/Service/AddressCheck/AddressCheckerWithCache.php
@@ -101,7 +101,6 @@ final class AddressCheckerWithCache implements AddressCheckerInterface
     {
         $addressCheckPayload = $this->addressCheckPayloadBuilder->buildFromCustomerAddress($addressEntity, $context);
 
-        // Include address entity ID to ensure different records with same content get separate cache entries
         $cacheData = [
             'addressContent' => $addressCheckPayload->toJSON(),
             'entityId' => $addressEntity->getId()

--- a/tests/Unit/Model/AddressCheckPayloadCombinedTest.php
+++ b/tests/Unit/Model/AddressCheckPayloadCombinedTest.php
@@ -1,0 +1,264 @@
+<?php declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Tests\Unit\Model;
+
+use Endereco\Shopware6Client\Model\AddressCheckPayloadCombined;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadInterface;
+use PHPUnit\Framework\TestCase;
+
+class AddressCheckPayloadCombinedTest extends TestCase
+{
+    /**
+     * Tests that constructor properly sets all properties and they are accessible via data() method.
+     */
+    public function testConstructorSetsAllProperties(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            'Additional info'
+        );
+
+        $data = $payload->data();
+
+        $this->assertSame('DE', $data['country']);
+        $this->assertSame('12345', $data['postCode']);
+        $this->assertSame('Berlin', $data['cityName']);
+        $this->assertSame('Lindenstraße 2', $data['streetFull']);
+        $this->assertSame('BE', $data['subdivisionCode']);
+        $this->assertSame('Additional info', $data['additionalInfo']);
+    }
+
+    /**
+     * Tests that null subdivision code and additional info are excluded from data array.
+     */
+    public function testDataArrayExcludesNullValues(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            null,
+            null
+        );
+
+        $data = $payload->data();
+
+        $this->assertArrayNotHasKey('subdivisionCode', $data);
+        $this->assertArrayNotHasKey('additionalInfo', $data);
+    }
+
+    /**
+     * Tests that empty string subdivision code and additional info are included in data array.
+     */
+    public function testDataArrayIncludesEmptyStringValues(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'US',
+            '90210',
+            'Beverly Hills',
+            '123 Main Street',
+            '',
+            ''
+        );
+
+        $data = $payload->data();
+
+        $this->assertArrayHasKey('subdivisionCode', $data);
+        $this->assertSame('', $data['subdivisionCode']);
+        $this->assertArrayHasKey('additionalInfo', $data);
+        $this->assertSame('', $data['additionalInfo']);
+    }
+
+    /**
+     * Tests that data array keys are sorted alphabetically for consistent signatures.
+     */
+    public function testDataArrayIsSorted(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            'Additional info'
+        );
+
+        $data = $payload->data();
+        $keys = array_keys($data);
+        $sortedKeys = $keys;
+        sort($sortedKeys);
+
+        $this->assertSame($sortedKeys, $keys);
+    }
+
+    /**
+     * Tests that toJSON() produces valid JSON string with correct data.
+     */
+    public function testToJSONProducesValidJson(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            'Additional info'
+        );
+
+        $json = $payload->toJSON();
+        
+        // Check JSON is valid
+        json_decode($json);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'JSON should be valid');
+        
+        // Compare JSON structure
+        $expectedJson = json_encode([
+            'additionalInfo' => 'Additional info',
+            'cityName' => 'Berlin',
+            'country' => 'DE',
+            'postCode' => '12345',
+            'streetFull' => 'Lindenstraße 2',
+            'subdivisionCode' => 'BE'
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        
+        $this->assertJsonStringEqualsJsonString($expectedJson, $json);
+    }
+
+    /**
+     * Tests that toJSON() properly handles Unicode characters without escaping.
+     */
+    public function testToJSONHandlesUnicodeCharacters(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'München',
+            'Bürgerstraße 5',
+            'BY',
+            'Zusätzliche Info'
+        );
+
+        $json = $payload->toJSON();
+        
+        // Check JSON is valid
+        json_decode($json);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'JSON with Unicode should be valid');
+        
+        // Verify Unicode characters are not escaped
+        $this->assertStringContainsString('München', $json);
+        $this->assertStringContainsString('Bürgerstraße', $json);
+        $this->assertStringContainsString('Zusätzliche Info', $json);
+    }
+
+    /**
+     * Tests that getFormatType() returns 'combined' identifier.
+     */
+    public function testGetFormatTypeReturnsCombined(): void
+    {
+        $payload = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            null
+        );
+
+        $this->assertSame(AddressCheckPayloadInterface::FORMAT_COMBINED, $payload->getFormatType());
+    }
+
+    /**
+     * Tests that identical address data produces consistent signatures for caching.
+     */
+    public function testConsistentSignatureForSameAddress(): void
+    {
+        $payload1 = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            'Additional info'
+        );
+
+        $payload2 = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            'Additional info'
+        );
+
+        $this->assertSame($payload1->toJSON(), $payload2->toJSON());
+        $this->assertSame($payload1->data(), $payload2->data());
+    }
+
+    /**
+     * Tests that different address data produces different signatures.
+     */
+    public function testDifferentSignatureForDifferentAddresses(): void
+    {
+        $payload1 = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            null
+        );
+
+        $payload2 = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 3',
+            'BE',
+            null
+        );
+
+        $this->assertNotEquals($payload1->toJSON(), $payload2->toJSON());
+        $this->assertNotEquals($payload1->data(), $payload2->data());
+    }
+
+    /**
+     * Tests that null vs empty string additional info produces different signatures.
+     */
+    public function testDifferentSignatureForNullVsEmptyAdditionalInfo(): void
+    {
+        $payloadWithNull = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            null
+        );
+
+        $payloadWithEmpty = new AddressCheckPayloadCombined(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße 2',
+            'BE',
+            ''
+        );
+
+        $this->assertNotEquals($payloadWithNull->toJSON(), $payloadWithEmpty->toJSON());
+        $this->assertNotEquals($payloadWithNull->data(), $payloadWithEmpty->data());
+        
+        // Verify the null version doesn't include additionalInfo field
+        $nullData = $payloadWithNull->data();
+        $this->assertArrayNotHasKey('additionalInfo', $nullData);
+        
+        // Verify the empty string version includes additionalInfo field
+        $emptyData = $payloadWithEmpty->data();
+        $this->assertArrayHasKey('additionalInfo', $emptyData);
+        $this->assertSame('', $emptyData['additionalInfo']);
+    }
+}

--- a/tests/Unit/Model/AddressCheckPayloadSplitTest.php
+++ b/tests/Unit/Model/AddressCheckPayloadSplitTest.php
@@ -1,0 +1,302 @@
+<?php declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Tests\Unit\Model;
+
+use Endereco\Shopware6Client\Model\AddressCheckPayloadSplit;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadInterface;
+use PHPUnit\Framework\TestCase;
+
+class AddressCheckPayloadSplitTest extends TestCase
+{
+    /**
+     * Tests that constructor properly sets all properties and they are accessible via data() method.
+     */
+    public function testConstructorSetsAllProperties(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            'Additional info'
+        );
+
+        $data = $payload->data();
+
+        $this->assertSame('DE', $data['country']);
+        $this->assertSame('12345', $data['postCode']);
+        $this->assertSame('Berlin', $data['cityName']);
+        $this->assertSame('Lindenstraße', $data['street']);
+        $this->assertSame('2', $data['houseNumber']);
+        $this->assertSame('BE', $data['subdivisionCode']);
+        $this->assertSame('Additional info', $data['additionalInfo']);
+    }
+
+    /**
+     * Tests that null subdivision code and additional info are excluded from data array.
+     */
+    public function testDataArrayExcludesNullValues(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            null,
+            null
+        );
+
+        $data = $payload->data();
+
+        $this->assertArrayNotHasKey('subdivisionCode', $data);
+        $this->assertArrayNotHasKey('additionalInfo', $data);
+    }
+
+    /**
+     * Tests that empty string subdivision code and additional info are included in data array.
+     */
+    public function testDataArrayIncludesEmptyStringValues(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'US',
+            '90210',
+            'Beverly Hills',
+            'Main Street',
+            '123',
+            '',
+            ''
+        );
+
+        $data = $payload->data();
+
+        $this->assertArrayHasKey('subdivisionCode', $data);
+        $this->assertSame('', $data['subdivisionCode']);
+        $this->assertArrayHasKey('additionalInfo', $data);
+        $this->assertSame('', $data['additionalInfo']);
+    }
+
+    /**
+     * Tests that data array keys are sorted alphabetically for consistent signatures.
+     */
+    public function testDataArrayIsSorted(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            'Additional info'
+        );
+
+        $data = $payload->data();
+        $keys = array_keys($data);
+        $sortedKeys = $keys;
+        sort($sortedKeys);
+
+        $this->assertSame($sortedKeys, $keys);
+    }
+
+    /**
+     * Tests that toJSON() produces valid JSON string with correct data.
+     */
+    public function testToJSONProducesValidJson(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            'Additional info'
+        );
+
+        $json = $payload->toJSON();
+        
+        // Check JSON is valid
+        json_decode($json);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'JSON should be valid');
+        
+        // Compare JSON structure
+        $expectedJson = json_encode([
+            'additionalInfo' => 'Additional info',
+            'cityName' => 'Berlin',
+            'country' => 'DE',
+            'houseNumber' => '2',
+            'postCode' => '12345',
+            'street' => 'Lindenstraße',
+            'subdivisionCode' => 'BE'
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        
+        $this->assertJsonStringEqualsJsonString($expectedJson, $json);
+    }
+
+    /**
+     * Tests that toJSON() properly handles Unicode characters without escaping.
+     */
+    public function testToJSONHandlesUnicodeCharacters(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'München',
+            'Bürgerstraße',
+            '5',
+            'BY',
+            'Zusätzliche Info'
+        );
+
+        $json = $payload->toJSON();
+        
+        // Check JSON is valid
+        json_decode($json);
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'JSON with Unicode should be valid');
+        
+        // Verify Unicode characters are not escaped
+        $this->assertStringContainsString('München', $json);
+        $this->assertStringContainsString('Bürgerstraße', $json);
+        $this->assertStringContainsString('Zusätzliche Info', $json);
+    }
+
+    /**
+     * Tests that getFormatType() returns 'split' identifier.
+     */
+    public function testGetFormatTypeReturnsSplit(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            null
+        );
+
+        $this->assertSame(AddressCheckPayloadInterface::FORMAT_SPLIT, $payload->getFormatType());
+    }
+
+    /**
+     * Tests that identical address data produces consistent signatures for caching.
+     */
+    public function testConsistentSignatureForSameAddress(): void
+    {
+        $payload1 = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            'Additional info'
+        );
+
+        $payload2 = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',  
+            'Lindenstraße',
+            '2',
+            'BE',
+            'Additional info'
+        );
+
+        $this->assertSame($payload1->toJSON(), $payload2->toJSON());
+        $this->assertSame($payload1->data(), $payload2->data());
+    }
+
+    /**
+     * Tests that different address data produces different signatures.
+     */
+    public function testDifferentSignatureForDifferentAddresses(): void
+    {
+        $payload1 = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            null
+        );
+
+        $payload2 = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '3',
+            'BE',
+            null
+        );
+
+        $this->assertNotEquals($payload1->toJSON(), $payload2->toJSON());
+        $this->assertNotEquals($payload1->data(), $payload2->data());
+    }
+
+    /**
+     * Tests that null vs empty string additional info produces different signatures.
+     */
+    public function testDifferentSignatureForNullVsEmptyAdditionalInfo(): void
+    {
+        $payloadWithNull = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            null
+        );
+
+        $payloadWithEmpty = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            ''
+        );
+
+        $this->assertNotEquals($payloadWithNull->toJSON(), $payloadWithEmpty->toJSON());
+        $this->assertNotEquals($payloadWithNull->data(), $payloadWithEmpty->data());
+        
+        // Verify the null version doesn't include additionalInfo field
+        $nullData = $payloadWithNull->data();
+        $this->assertArrayNotHasKey('additionalInfo', $nullData);
+        
+        // Verify the empty string version includes additionalInfo field
+        $emptyData = $payloadWithEmpty->data();
+        $this->assertArrayHasKey('additionalInfo', $emptyData);
+        $this->assertSame('', $emptyData['additionalInfo']);
+    }
+
+    /**
+     * Tests that split format uses separate street and houseNumber fields instead of streetFull.
+     */
+    public function testSplitFieldsUseDifferentKeysFromCombined(): void
+    {
+        $payload = new AddressCheckPayloadSplit(
+            'DE',
+            '12345',
+            'Berlin',
+            'Lindenstraße',
+            '2',
+            'BE',
+            null
+        );
+
+        $data = $payload->data();
+
+        // Split format uses 'street' and 'houseNumber' instead of 'streetFull'
+        $this->assertArrayHasKey('street', $data);
+        $this->assertArrayHasKey('houseNumber', $data);
+        $this->assertArrayNotHasKey('streetFull', $data);
+    }
+}

--- a/tests/Unit/Service/AddressCheckPayloadBuilderTest.php
+++ b/tests/Unit/Service/AddressCheckPayloadBuilderTest.php
@@ -1,0 +1,509 @@
+<?php declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Tests\Unit\Service\AddressCheck;
+
+use Endereco\Shopware6Client\Model\AddressCheckPayloadCombined;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadInterface;
+use Endereco\Shopware6Client\Model\AddressCheckPayloadSplit;
+use Endereco\Shopware6Client\Service\AddressCheck\AddressCheckPayloadBuilder;
+use Endereco\Shopware6Client\Service\AddressCheck\AddressCheckPayloadBuilderInterface;
+use Endereco\Shopware6Client\Service\AddressCheck\AdditionalAddressFieldCheckerInterface;
+use Endereco\Shopware6Client\Service\AddressCheck\CountryCodeFetcherInterface;
+use Endereco\Shopware6Client\Service\AddressCheck\CountryHasStatesCheckerInterface;
+use Endereco\Shopware6Client\Service\AddressCheck\SubdivisionCodeFetcherInterface;
+use Endereco\Shopware6Client\Service\AddressCorrection\StreetSplitterInterface;
+use Endereco\Shopware6Client\DTO\SplitStreetResultDto;
+use Endereco\Shopware6Client\Service\EnderecoService;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+class AddressCheckPayloadBuilderTest extends TestCase
+{
+    private CountryCodeFetcherInterface $countryCodeFetcher;
+    private SubdivisionCodeFetcherInterface $subdivisionCodeFetcher;
+    private CountryHasStatesCheckerInterface $countryHasStatesChecker;
+    private AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker;
+    private SystemConfigService $systemConfigService;
+    private StreetSplitterInterface $streetSplitter;
+    private EntityRepository $customerAddressExtensionRepository;
+    private EntityRepository $orderAddressExtensionRepository;
+    private EnderecoService $enderecoService;
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+    }
+
+    /**
+     * Creates a payload builder with mocked dependencies and optional configurations.
+     * 
+     * @param array<string, mixed> $config Configuration for common scenarios:
+     *   - 'splitStreetEnabled' => bool: Configure split street setting
+     *   - 'countryCode' => string: Default country code to return
+     *   - 'hasStates' => bool: Whether country has states
+     *   - 'hasAdditionalField' => bool: Whether additional address field is available
+     *   - 'additionalFieldName' => string: Name of additional field
+     *   - 'subdivisionCode' => string|null: Subdivision code to return
+     * @return AddressCheckPayloadBuilder
+     */
+    private function createPayloadBuilder(array $config = []): AddressCheckPayloadBuilder
+    {
+        // Create mocks
+        $this->countryCodeFetcher = $this->createMock(CountryCodeFetcherInterface::class);
+        $this->subdivisionCodeFetcher = $this->createMock(SubdivisionCodeFetcherInterface::class);
+        $this->countryHasStatesChecker = $this->createMock(CountryHasStatesCheckerInterface::class);
+        $this->additionalAddressFieldChecker = $this->createMock(AdditionalAddressFieldCheckerInterface::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->streetSplitter = $this->createMock(StreetSplitterInterface::class);
+        $this->customerAddressExtensionRepository = $this->createMock(EntityRepository::class);
+        $this->orderAddressExtensionRepository = $this->createMock(EntityRepository::class);
+        $this->enderecoService = $this->createMock(EnderecoService::class);
+
+        // Configure common defaults that can be overridden
+        if (isset($config['splitStreetEnabled'])) {
+            $this->systemConfigService->method('getBool')->willReturn($config['splitStreetEnabled']);
+        }
+        
+        if (isset($config['countryCode'])) {
+            $this->countryCodeFetcher->method('fetchCountryCodeByCountryIdAndContext')->willReturn($config['countryCode']);
+        }
+        
+        if (isset($config['hasStates'])) {
+            $this->countryHasStatesChecker->method('hasCountryStates')->willReturn($config['hasStates']);
+        }
+        
+        if (isset($config['hasAdditionalField'])) {
+            $this->additionalAddressFieldChecker->method('hasAdditionalAddressField')->willReturn($config['hasAdditionalField']);
+        }
+        
+        if (isset($config['additionalFieldName'])) {
+            $this->additionalAddressFieldChecker->method('getAvailableAdditionalAddressFieldName')->willReturn($config['additionalFieldName']);
+        }
+        
+        if (isset($config['subdivisionCode'])) {
+            $this->subdivisionCodeFetcher->method('fetchSubdivisionCodeByCountryStateId')->willReturn($config['subdivisionCode']);
+        }
+
+        return new AddressCheckPayloadBuilder(
+            $this->countryCodeFetcher,
+            $this->subdivisionCodeFetcher,
+            $this->countryHasStatesChecker,
+            $this->additionalAddressFieldChecker,
+            $this->systemConfigService,
+            $this->streetSplitter,
+            $this->customerAddressExtensionRepository,
+            $this->orderAddressExtensionRepository,
+            $this->enderecoService
+        );
+    }
+
+    /**
+     * Tests that buildFromArray returns a combined payload when split street format is disabled.
+     */
+    public function testBuildFromArrayReturnsCombinedPayloadWhenSplitFormatDisabled(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => false,
+            'countryCode' => 'DE',
+            'hasStates' => false,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1'
+        ]);
+
+        // Still need to set specific expectations for testing
+        $this->systemConfigService
+            ->expects($this->once())
+            ->method('getBool')
+            ->with(AddressCheckPayloadBuilderInterface::CONFIG_SPLIT_STREET, null);
+
+        $this->countryCodeFetcher
+            ->expects($this->once())
+            ->method('fetchCountryCodeByCountryIdAndContext');
+
+        $this->countryHasStatesChecker
+            ->expects($this->once())
+            ->method('hasCountryStates');
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('hasAdditionalAddressField')
+            ->with($this->context);
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('getAvailableAdditionalAddressFieldName')
+            ->with($this->context);
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'zipcode' => '12345',
+            'city' => 'Berlin',
+            'street' => 'Lindenstraße 2',
+            'additionalAddressLine1' => 'Additional info',
+            'additionalAddressLine2' => null,
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $this->context);
+
+        $this->assertInstanceOf(AddressCheckPayloadCombined::class, $payload);
+        $this->assertSame(AddressCheckPayloadInterface::FORMAT_COMBINED, $payload->getFormatType());
+    }
+
+    /**
+     * Tests that buildFromArray returns a split payload when split street format is enabled.
+     */
+    public function testBuildFromArrayReturnsSplitPayloadWhenSplitFormatEnabled(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => true,
+            'countryCode' => 'DE',
+            'hasStates' => false,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1'
+        ]);
+
+        // Still need to set specific expectations for testing
+        $this->systemConfigService
+            ->expects($this->once())
+            ->method('getBool')
+            ->with(AddressCheckPayloadBuilderInterface::CONFIG_SPLIT_STREET, null);
+
+        $this->countryCodeFetcher
+            ->expects($this->once())
+            ->method('fetchCountryCodeByCountryIdAndContext');
+
+        $this->countryHasStatesChecker
+            ->expects($this->once())
+            ->method('hasCountryStates');
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('hasAdditionalAddressField')
+            ->with($this->context);
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('getAvailableAdditionalAddressFieldName')
+            ->with($this->context);
+
+        $this->streetSplitter
+            ->expects($this->once())
+            ->method('splitStreet')
+            ->with('Lindenstraße 2')
+            ->willReturn(new SplitStreetResultDto(
+                'Lindenstraße 2',
+                'Lindenstraße',
+                '2',
+                null
+            ));
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'zipcode' => '12345',
+            'city' => 'Berlin',
+            'street' => 'Lindenstraße 2',
+            'additionalAddressLine1' => 'Additional info',
+            'additionalAddressLine2' => null,
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $this->context);
+
+        $this->assertInstanceOf(AddressCheckPayloadSplit::class, $payload);
+        $this->assertSame(AddressCheckPayloadInterface::FORMAT_SPLIT, $payload->getFormatType());
+    }
+
+    /**
+     * Tests that buildFromArray uses sales channel specific system configuration when context contains sales channel.
+     */
+    public function testBuildFromArrayUsesSystemConfigWithSalesChannelContext(): void
+    {
+        $salesChannelId = 'test-sales-channel-id';
+        $source = new SalesChannelApiSource($salesChannelId);
+        $context = new Context($source);
+
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => false,
+            'countryCode' => 'DE',
+            'hasStates' => false,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1'
+        ]);
+
+        $this->systemConfigService
+            ->expects($this->once())
+            ->method('getBool')
+            ->with(AddressCheckPayloadBuilderInterface::CONFIG_SPLIT_STREET, $salesChannelId);
+
+        $this->countryCodeFetcher
+            ->expects($this->once())
+            ->method('fetchCountryCodeByCountryIdAndContext');
+
+        $this->countryHasStatesChecker
+            ->expects($this->once())
+            ->method('hasCountryStates');
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('hasAdditionalAddressField')
+            ->with($context);
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('getAvailableAdditionalAddressFieldName')
+            ->with($context);
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'zipcode' => '12345',
+            'city' => 'Berlin',
+            'street' => 'Lindenstraße 2',
+            'additionalAddressLine1' => null,
+            'additionalAddressLine2' => null,
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $context);
+
+        $this->assertInstanceOf(AddressCheckPayloadCombined::class, $payload);
+    }
+
+    /**
+     * Tests that the same address data produces different payloads when format setting changes,
+     * ensuring different API signatures to force status code cache invalidation.
+     */
+    public function testSameAddressDataProducesDifferentPayloadsWhenFormatSettingChanges(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'countryCode' => 'DE',
+            'hasStates' => false,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1'
+        ]);
+        
+        $addressData = [
+            'countryId' => 'country-id',
+            'zipcode' => '12345',
+            'city' => 'Berlin',
+            'street' => 'Lindenstraße 2',
+            'additionalAddressLine1' => 'Additional info',
+            'additionalAddressLine2' => null,
+        ];
+
+        // Setup common mock expectations - factory handles defaults
+        $this->countryCodeFetcher
+            ->expects($this->exactly(2))
+            ->method('fetchCountryCodeByCountryIdAndContext');
+
+        $this->countryHasStatesChecker
+            ->expects($this->exactly(2))
+            ->method('hasCountryStates');
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->exactly(2))
+            ->method('hasAdditionalAddressField');
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->exactly(2))
+            ->method('getAvailableAdditionalAddressFieldName');
+
+        // First call: combined format (split disabled)
+        $this->systemConfigService
+            ->expects($this->exactly(2))
+            ->method('getBool')
+            ->with(AddressCheckPayloadBuilderInterface::CONFIG_SPLIT_STREET, null)
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        // Mock street splitter for split format
+        $this->streetSplitter
+            ->expects($this->once())
+            ->method('splitStreet')
+            ->with('Lindenstraße 2')
+            ->willReturn(new SplitStreetResultDto(
+                'Lindenstraße 2',
+                'Lindenstraße',
+                '2',
+                'Additional info'
+            ));
+
+        // Build payloads with different format settings
+        $combinedPayload = $payloadBuilder->buildFromArray($addressData, $this->context);
+        $splitPayload = $payloadBuilder->buildFromArray($addressData, $this->context);
+
+        // Verify different payload types are created
+        $this->assertInstanceOf(AddressCheckPayloadCombined::class, $combinedPayload);
+        $this->assertInstanceOf(AddressCheckPayloadSplit::class, $splitPayload);
+        
+        // Verify different format types
+        $this->assertSame(AddressCheckPayloadInterface::FORMAT_COMBINED, $combinedPayload->getFormatType());
+        $this->assertSame(AddressCheckPayloadInterface::FORMAT_SPLIT, $splitPayload->getFormatType());
+
+        // Most importantly: verify the payloads are different
+        // This ensures different API signatures and forces status code refresh
+        $combinedData = $combinedPayload->data();
+        $splitData = $splitPayload->data();
+        
+        $this->assertNotEquals($combinedData, $splitData, 'Payloads should be different when format setting changes');
+        
+        // Verify that combined format has full street
+        $this->assertSame('Lindenstraße 2', $combinedData['streetFull']);
+        $this->assertArrayNotHasKey('street', $combinedData);
+        $this->assertArrayNotHasKey('houseNumber', $combinedData);
+        
+        // Verify that split format has separate street name and building number  
+        $this->assertSame('Lindenstraße', $splitData['street']);
+        $this->assertSame('2', $splitData['houseNumber']);
+        $this->assertArrayNotHasKey('streetFull', $splitData);
+    }
+
+    /**
+     * Tests that subdivision codes are correctly fetched and included in payload for addresses with states.
+     */
+    public function testHandlesSubdivisionCodeCorrectly(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => false,
+            'countryCode' => 'US',
+            'hasStates' => true,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1',
+            'subdivisionCode' => 'CA'
+        ]);
+
+        $this->subdivisionCodeFetcher
+            ->expects($this->once())
+            ->method('fetchSubdivisionCodeByCountryStateId')
+            ->with('state-id', $this->context);
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'countryStateId' => 'state-id',
+            'zipcode' => '90210',
+            'city' => 'Beverly Hills',
+            'street' => '123 Main Street',
+            'additionalAddressLine1' => null,
+            'additionalAddressLine2' => null,
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $this->context);
+        $data = $payload->data();
+
+        $this->assertSame('CA', $data['subdivisionCode']);
+    }
+
+    /**
+     * Tests that empty subdivision code is set when country has states but no state is selected.
+     */
+    public function testHandlesCountryWithStatesButNoStateSelected(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => false,
+            'countryCode' => 'US',
+            'hasStates' => true,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1'
+        ]);
+
+        $this->subdivisionCodeFetcher
+            ->expects($this->never())
+            ->method('fetchSubdivisionCodeByCountryStateId');
+
+        $this->countryHasStatesChecker
+            ->expects($this->once())
+            ->method('hasCountryStates')
+            ->with('country-id', $this->context);
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('hasAdditionalAddressField')
+            ->with($this->context);
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'countryStateId' => '',
+            'zipcode' => '90210',
+            'city' => 'Beverly Hills',
+            'street' => '123 Main Street',
+            'additionalAddressLine1' => null,
+            'additionalAddressLine2' => null,
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $this->context);
+        $data = $payload->data();
+
+        $this->assertSame('', $data['subdivisionCode']);
+    }
+
+    /**
+     * Tests that subdivision code is omitted from payload when country has no states.
+     */
+    public function testHandlesCountryWithoutStates(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => false,
+            'countryCode' => 'DE',
+            'hasStates' => false,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine1'
+        ]);
+
+        $this->countryHasStatesChecker
+            ->expects($this->once())
+            ->method('hasCountryStates')
+            ->with('country-id', $this->context);
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'zipcode' => '12345',
+            'city' => 'Berlin',
+            'street' => 'Lindenstraße 2',
+            'additionalAddressLine1' => null,
+            'additionalAddressLine2' => null,
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $this->context);
+        $data = $payload->data();
+
+        $this->assertArrayNotHasKey('subdivisionCode', $data);
+    }
+
+    /**
+     * Tests that additional address info is correctly extracted based on available field configuration.
+     */
+    public function testHandlesAdditionalAddressInfo(): void
+    {
+        $payloadBuilder = $this->createPayloadBuilder([
+            'splitStreetEnabled' => false,
+            'countryCode' => 'DE',
+            'hasStates' => false,
+            'hasAdditionalField' => true,
+            'additionalFieldName' => 'additionalAddressLine2'
+        ]);
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('hasAdditionalAddressField')
+            ->with($this->context);
+
+        $this->additionalAddressFieldChecker
+            ->expects($this->once())
+            ->method('getAvailableAdditionalAddressFieldName')
+            ->with($this->context);
+
+        $addressData = [
+            'countryId' => 'country-id',
+            'zipcode' => '12345',
+            'city' => 'Berlin',
+            'street' => 'Lindenstraße 2',
+            'additionalAddressLine1' => 'First additional info',
+            'additionalAddressLine2' => 'Second additional info',
+        ];
+
+        $payload = $payloadBuilder->buildFromArray($addressData, $this->context);
+        $data = $payload->data();
+
+        $this->assertSame('Second additional info', $data['additionalInfo']);
+    }
+}


### PR DESCRIPTION
Replace HTML entity `&auml;` with the correct German Umlaut 'ä' in two locations within the German snippet file.
This fixes an issue where the modal was escaping the HTML entities, causing them to be displayed as literal text instead of the intended character.

Ref: DEV-278