### PR TITLE
Replace HTML entities with UTF-8 characters in German snippets

### DIFF
--- a/src/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Resources/snippet/de_DE/storefront.de-DE.json
@@ -2,7 +2,7 @@
     "enderecoshopware6client": {
         "texts": {
             "popUpHeadline": "Adresse prüfen",
-            "popUpSubline": "Die von Ihnen eingegebene Adresse scheint nicht korrekt oder unvollst&auml;ndig zu sein. Bitte w&auml;hlen Sie die korrekte Adresse aus.",
+            "popUpSubline": "Die von Ihnen eingegebene Adresse scheint nicht korrekt oder unvollständig zu sein. Bitte wählen Sie die korrekte Adresse aus.",
             "yourInput": "Ihre Eingabe:",
             "editYourInput": "(bearbeiten)",
             "ourSuggestions": "Unsere Vorschläge:",


### PR DESCRIPTION
Replace HTML entity `&auml;` with the correct German Umlaut 'ä' in two locations within the German snippet file.
This fixes an issue where the modal was escaping the HTML entities, causing them to be displayed as literal text instead of the intended character.

Ref: DEV-278