### PR TITLE
Fix street overwrite when customer confirmed unvalidated address

### DIFF
--- a/src/Service/AddressIntegrity/CustomerAddress/StreetIsSplitInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/StreetIsSplitInsurance.php
@@ -7,6 +7,7 @@ namespace Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress;
 use Endereco\Shopware6Client\DTO\CustomerAddressDTO;
 use Endereco\Shopware6Client\DTO\SplitStreetResultDto;
 use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\EnderecoBaseAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
 use Endereco\Shopware6Client\Service\AddressCheck\AdditionalAddressFieldCheckerInterface;
 use Endereco\Shopware6Client\Service\AddressCheck\CountryCodeFetcherInterface;
@@ -90,6 +91,14 @@ final class StreetIsSplitInsurance implements IntegrityInsurance
         $addressExtension = $addressEntity->getExtension(CustomerAddressExtension::ENDERECO_EXTENSION);
         if (!$addressExtension instanceof EnderecoCustomerAddressExtensionEntity) {
             throw new \RuntimeException('The address extension should be set at this point');
+        }
+
+        // If the user explicitly confirmed the original address, skip street splitting entirely
+        // to prevent the API from overwriting street/additionalAddressLine
+        // (e.g. "Nr." being extracted as additionalInfo).
+        $amsStatus = $addressExtension->getAmsStatus();
+        if (str_contains($amsStatus, EnderecoBaseAddressExtensionEntity::AMS_STATUS_SELECTED_BY_CUSTOMER)) {
+            return;
         }
 
         list($countryCode, $fullStreet, $additionalInfo) = $this->getRelevantData($addressEntity, $context);

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -6,6 +6,7 @@ namespace Endereco\Shopware6Client\Service;
 
 use Endereco\Shopware6Client\DTO\CustomerAddressDTO;
 use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\EnderecoBaseAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
@@ -436,6 +437,14 @@ class EnderecoService
         $isFullStreetEmpty = empty($addressData['street']);
         $isStreetNameEmpty = empty($addressData['extensions'][$extensionName]['street']);
 
+        // If the user explicitly confirmed the original address, do not overwrite additionalAddressLine
+        // with data from the splitStreet API (e.g. "Nr." being extracted as additionalInfo).
+        $amsStatus = $addressData['extensions'][$extensionName]['amsStatus'] ?? '';
+        $isAddressSelectedByCustomer = str_contains(
+            $amsStatus,
+            EnderecoBaseAddressExtensionEntity::AMS_STATUS_SELECTED_BY_CUSTOMER
+        );
+
         // Create payload objects for normalized updates
         $customerAddressPayload = new CustomerAddressUpdatePayload('sync_street');
         $extensionData = new EnderecoExtensionData();
@@ -495,6 +504,16 @@ class EnderecoService
                 $context,
                 $salesChannelId
             );
+
+            // If the user confirmed the address, only populate extension fields
+            // and skip overwriting street/additionalAddressLine to prevent the API
+            // from stripping parts like "Nr." into additionalInfo.
+            if ($isAddressSelectedByCustomer) {
+                $extensionData->setStreet($streetSplitResult->getStreetName());
+                $extensionData->setHouseNumber($streetSplitResult->getBuildingNumber());
+                $this->extensionArrayUpdater->updateFromExtensionPayload($extensionData, $addressData);
+                return;
+            }
 
             // Set split results in payload objects
             $customerAddressPayload->setStreet($streetSplitResult->getFullStreet());
@@ -564,6 +583,16 @@ class EnderecoService
                     $context,
                     $salesChannelId
                 );
+
+                // If the user confirmed the address, only populate extension fields
+                // and skip overwriting street/additionalAddressLine to prevent the API
+                // from stripping parts like "Nr." into additionalInfo.
+                if ($isAddressSelectedByCustomer) {
+                    $extensionData->setStreet($splitStreetResult->getStreetName());
+                    $extensionData->setHouseNumber($splitStreetResult->getBuildingNumber());
+                    $this->extensionArrayUpdater->updateFromExtensionPayload($extensionData, $addressData);
+                    return;
+                }
 
                 // Set split results in payload objects
                 $customerAddressPayload->setStreet($splitStreetResult->getFullStreet());


### PR DESCRIPTION
Problem:
An address explicitly confirmed by the customer was not assumed 1:1 by
the Endereco module because the address was normalised and corrected
by street splitting.

Solution:
The system now checks whether the amsStatus contains the value 
"address_selected_by_customer". If the value is set, the overwriting of 
street and additionalAddressLine is skipped via early exit.
The status "address_selected_by_customer" is set during account
registration or in the address book (create, change) if the
customer:
- confirms an address that is displayed by the Endereco module
  in the modal, or
- does not accept an auto-correction made by the Endereco
  module and reverses it (data is moved back from additional
  address line to street).

Tests:
The module's behaviour was tested using addresses from the list
"Testanleitung für Javascript / Shopmodule - Adressprüfung" by
confirming incorrect addresses.
The tests were carried out both during account registration and in the 
customer account in the address book (change, create new), delete.

See DEV-332 for further details.