### PR TITLE
Fix problems during js minify

### DIFF
--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -154,7 +154,7 @@
                         emailService: {{ page.endereco_config.enderecoEmailCheckActive ? 'true':'false' }},
                         personService: {{ page.endereco_config.enderecoNameCheckActive ? 'true':'false' }},
                         phs: {{ page.endereco_config.enderecoPhsActive ? 'true':'false' }}
-                    }
+                    };
 
                     // Execute all function that have been called throughout the page.
                     window.EnderecoIntegrator.onLoad.forEach(function (callback) {
@@ -269,7 +269,7 @@
                             stop: function () {
 
                             }
-                        }
+                        };
                         window.EnderecoIntegrator.$formScanner.start();
                     })();
                 }


### PR DESCRIPTION
Problem:
Minification (e.g. using the PageSpeed plugin) cannot be completed successfully due to missing semicolons.

Solution:
Semicolons added in lines 157 and 272 of the file
src/Resources/views/storefront/layout/meta.html.twig.

Tests:
npm terser; PageSpeed Insights

See DEV-325 for further details.