### PR TITLE
Fix perpetual writes to address extension table

### DIFF
--- a/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/AmazonFlagIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/AmazonFlagIsSetInsurance.php
@@ -58,7 +58,9 @@ final class AmazonFlagIsSetInsurance implements IntegrityInsurance
 
         $customer = $this->getCustomer($addressEntity->getCustomerId(), $context);
         $flagValue = $this->checkIfFromAmazon($customer);
-        $this->persistFlagValue($addressExtension, $flagValue, $context);
+        if ($addressExtension->isAmazonPayAddress() !== $flagValue) {
+            $this->persistFlagValue($addressExtension, $flagValue, $context);
+        }
         $this->setFlagInExtension($addressExtension, $flagValue);
     }
 

--- a/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
@@ -58,7 +58,9 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
 
         $customer = $this->getCustomer($addressEntity->getCustomerId(), $context);
         $flagValue = $this->checkIfFromPayPal($customer);
-        $this->persistFlagValue($addressExtension, $flagValue, $context);
+        if ($addressExtension->isPayPalAddress() !== $flagValue) {
+            $this->persistFlagValue($addressExtension, $flagValue, $context);
+        }
         $this->setFlagInExtension($addressExtension, $flagValue);
     }
 


### PR DESCRIPTION
Problem:

The updated_at column in endereco_customer_address_ext_(gh|sw) was being
updated on every page browse, even when no address data had changed.

Solution:

AmazonFlagIsSetInsurance and PayPalExpressFlagIsSetInsurance called
persistFlagValue() unconditionally on every address load, regardless
of whether the stored flag value differed from the computed one. Both
classes now compare the current extension value against the computed
flag before writing, so the DB is only touched when a change is
actually needed.

Test:

After the changes were made, no further write accesses to
endereco_customer_address_ext_gh were recorded on the local system
while browsing the shop.

See DEV-337 for further details.