### PR TITLE
Add CrefoPay PayPal Express session protection and guest enrichment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "endereco/endereco-shopware6-client",
     "description": "Checks customers' addresses in real time. In case of errors, the customer is prompted to correct his address before sending via warning windows and error messages.",
-    "version": "6.6.3",
+    "version": "6.6.4",
     "type": "shopware-platform-plugin",
     "license": "AGPL-3.0-or-later",
     "authors": [

--- a/src/Entity/CustomerAddress/CustomerAddressExtension.php
+++ b/src/Entity/CustomerAddress/CustomerAddressExtension.php
@@ -33,13 +33,8 @@ class CustomerAddressExtension extends EntityExtension
         );
     }
 
-    /**
-     * Get the class name of the definition that is extended by this extension.
-     *
-     * @return string The class name of the extended definition.
-     */
-    public function getDefinitionClass(): string
+    public function getEntityName(): string
     {
-        return CustomerAddressDefinition::class;
+        return CustomerAddressDefinition::ENTITY_NAME;
     }
 }

--- a/src/Entity/OrderAddress/OrderAddressExtension.php
+++ b/src/Entity/OrderAddress/OrderAddressExtension.php
@@ -36,13 +36,8 @@ class OrderAddressExtension extends EntityExtension
         $collection->add($associationField);
     }
 
-    /**
-     * Get the class name of the definition that is extended by this extension.
-     *
-     * @return string The class name of the extended definition.
-     */
-    public function getDefinitionClass(): string
+    public function getEntityName(): string
     {
-        return OrderAddressDefinition::class;
+        return OrderAddressDefinition::ENTITY_NAME;
     }
 }

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -213,6 +213,15 @@
         </input-field>
 
         <input-field type="bool">
+            <name>enderecoCheckCrefoPayPayPalExpressAddress</name>
+            <label>Check addresses via CrefoPay PayPal Express Checkout</label>
+            <label lang="de-DE">Adressen über CrefoPay PayPal Express Checkout prüfen</label>
+            <helpText>The CrefoPay PayPal Express check activates the validation of addresses for customers who place an order via CrefoPay with PayPal Express payment method. When returning from PayPal to the shop, a correction suggestion is displayed in case of an address error. This feature works analogously to the standard PayPal Express address check.</helpText>
+            <helpText lang="de-DE">Die CrefoPay PayPal Express Prüfung aktiviert die Validierung von Adressen für Kunden, die über CrefoPay mit der Zahlungsart PayPal Express eine Bestellung tätigen. Beim Rücksprung aus PayPal zum Shop wird bei einem Adressfehler ein Korrekturvorschlag angezeigt. Diese Funktion arbeitet analog zur Standard PayPal Express Adressprüfung.</helpText>
+            <defaultValue>false</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
             <name>enderecoWriteOrderCustomFields</name>
             <label>Write order billing and shipping address validation data to order `custom_fields`</label>
             <label lang="de-DE">Validierungsdaten der Rechnungs- und Lieferadressen einer Bestellung in `custom_fields` schreiben</label>

--- a/src/Resources/config/services/subscriber.php
+++ b/src/Resources/config/services/subscriber.php
@@ -23,6 +23,8 @@ use Endereco\Shopware6Client\Subscriber\ConvertCartToOrderSubscriber;
 use Endereco\Shopware6Client\Subscriber\CustomerAddressSubscriber;
 use Endereco\Shopware6Client\Subscriber\OrderSubscriber;
 use Endereco\Shopware6Client\Subscriber\OrderAddressSubscriber;
+use Endereco\Shopware6Client\Subscriber\CrefoPayPayPalCustomerSubscriber;
+use Endereco\Shopware6Client\Subscriber\CrefoPayPayPalSessionProtectionSubscriber;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Endereco\Shopware6Client\Subscriber\AddDataToPageSubscriber;
@@ -85,6 +87,21 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$orderAddressRepository' => service('order_address.repository'),
             '$bySystemConfigFilter' => service(BySystemConfigFilterInterface::class),
             '$ordersCustomFieldsUpdater' => service(OrdersCustomFieldsUpdaterInterface::class),
+        ])
+        ->tag('kernel.event_subscriber');
+
+    $services->set(CrefoPayPayPalCustomerSubscriber::class)
+        ->args([
+            '$customerRepository' => service('customer.repository'),
+            '$systemConfigService' => service(SystemConfigService::class),
+            '$enderecoService' => service(EnderecoService::class),
+        ])
+        ->tag('kernel.event_subscriber');
+
+    $services->set(CrefoPayPayPalSessionProtectionSubscriber::class)
+        ->args([
+            '$systemConfigService' => service(SystemConfigService::class),
+            '$enderecoService' => service(EnderecoService::class),
         ])
         ->tag('kernel.event_subscriber');
 };

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -621,11 +621,11 @@ class EnderecoService
      * This method checks if the Endereco plugin is active for a specified sales channel and if the API key is set.
      * Both of these conditions must be met for the plugin to be considered active.
      *
-     * @param string $salesChannelId The ID of the sales channel to check. If null, the default channel is used.
+     * @param string|null $salesChannelId The ID of the sales channel to check. If null, the default channel is used.
      * @return bool Returns true if the plugin is active for the given sales channel and the API key is set,
      *              false otherwise.
      */
-    public function isEnderecoPluginActive(string $salesChannelId): bool
+    public function isEnderecoPluginActive(?string $salesChannelId): bool
     {
         // Check if the plugin is active for this channel
         $isActiveForThisChannel = $this->systemConfigService

--- a/src/Service/SessionManagementService.php
+++ b/src/Service/SessionManagementService.php
@@ -22,7 +22,7 @@ class SessionManagementService
     private RequestHeadersGeneratorInterface $requestHeadersGenerator;
     private PayloadPreparatorInterface $payloadPreparator;
     private LoggerInterface $logger;
-    private ?SessionInterface $session;
+    private RequestStack $requestStack;
 
     public bool $isProcessingInsurances = false;
 
@@ -37,13 +37,18 @@ class SessionManagementService
         $this->systemConfigService = $systemConfigService;
         $this->requestHeadersGenerator = $requestHeadersGenerator;
         $this->payloadPreparator = $payloadPreparator;
+        $this->requestStack = $requestStack;
         $this->logger = $logger;
+    }
 
-        if (!is_null($requestStack->getMainRequest())) {
-            $this->session = $requestStack->getMainRequest()->getSession();
-        } else {
-            $this->session = null;
+    private function getCurrentSession(): ?SessionInterface
+    {
+        $request = $this->requestStack->getMainRequest();
+        if ($request === null || !$request->hasSession()) {
+            return null;
         }
+
+        return $request->getSession();
     }
 
     /**
@@ -178,7 +183,8 @@ class SessionManagementService
      */
     public function closeStoredSessions(Context $context, string $salesChannelId): void
     {
-        if (!$this->session instanceof SessionInterface) {
+        $session = $this->getCurrentSession();
+        if (!$session instanceof SessionInterface) {
             return;
         }
 
@@ -190,22 +196,23 @@ class SessionManagementService
         }
 
         // Check if there are any stored sessions in 'enderecoAccountableSessions'
-        if ($this->session->get('enderecoAccountableSessions')) {
+        if ($session->get('enderecoAccountableSessions')) {
 
             /** @var string[] $existingSessionIds */
-            $existingSessionIds = $this->session->get('enderecoAccountableSessions');
+            $existingSessionIds = $session->get('enderecoAccountableSessions');
 
             // If the retrieved session IDs array is not empty, proceed to close the sessions
             if (!empty($existingSessionIds)) {
                 // Call the service method to close the sessions
                 $this->sendDoAccountings($existingSessionIds, $context, $salesChannelId);
 
-                if (!$this->session instanceof SessionInterface) {
+                $sessionAfter = $this->getCurrentSession();
+                if (!$sessionAfter instanceof SessionInterface) {
                     return;
                 }
 
                 // Reset the 'enderecoAccountableSessions' array in the session
-                $this->session->set('enderecoAccountableSessions', []);
+                $sessionAfter->set('enderecoAccountableSessions', []);
             }
         }
     }
@@ -226,15 +233,16 @@ class SessionManagementService
      */
     public function addAccountableSessionIdsToStorage(array $sessionIds): void
     {
-        if (!$this->session instanceof SessionInterface) {
+        $session = $this->getCurrentSession();
+        if (!$session instanceof SessionInterface) {
             return;
         }
 
         // Fetch any existing sessions stored under 'enderecoAccountableSessions'
         $existingSessions = [];
 
-        if ($this->session->get('enderecoAccountableSessions')) {
-            $existingSessions = $this->session->get('enderecoAccountableSessions');
+        if ($session->get('enderecoAccountableSessions')) {
+            $existingSessions = $session->get('enderecoAccountableSessions');
         }
 
         // Merge the existing sessions with the new ones
@@ -244,7 +252,7 @@ class SessionManagementService
         $allSessions = array_unique($allSessions);
 
         // Store the resulting array back into the 'enderecoAccountableSessions' session storage
-        $this->session->set('enderecoAccountableSessions', $allSessions);
+        $session->set('enderecoAccountableSessions', $allSessions);
     }
 
     /**

--- a/src/Subscriber/CrefoPayPayPalCustomerSubscriber.php
+++ b/src/Subscriber/CrefoPayPayPalCustomerSubscriber.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Subscriber;
+
+use Endereco\Shopware6Client\Service\EnderecoService;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\CustomerEvents;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscriber to set payPalExpressPayerId for CrefoPay PayPal Express guest customers.
+ *
+ * This subscriber listens to customer creation events and sets the payPalExpressPayerId
+ * custom field for guest customers created via CrefoPay PayPal Express checkout.
+ * This ensures that Endereco can properly identify these addresses as PayPal Express addresses.
+ */
+class CrefoPayPayPalCustomerSubscriber implements EventSubscriberInterface
+{
+    private const CREFO_PAY_PAYPAL_PAYMENT_METHOD_ID = '8d33bb143f554c3dabc4f604f03a6f16';
+    private const CONFIG_KEY_CREFO_PAY_PAYPAL_CHECK =
+        'EnderecoShopware6Client.config.enderecoCheckCrefoPayPayPalExpressAddress';
+
+    private EntityRepository $customerRepository;
+    private SystemConfigService $systemConfigService;
+    private EnderecoService $enderecoService;
+
+    public function __construct(
+        EntityRepository $customerRepository,
+        SystemConfigService $systemConfigService,
+        EnderecoService $enderecoService
+    ) {
+        $this->customerRepository = $customerRepository;
+        $this->systemConfigService = $systemConfigService;
+        $this->enderecoService = $enderecoService;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CustomerEvents::CUSTOMER_WRITTEN_EVENT => 'onCustomerWritten',
+        ];
+    }
+
+    public function onCustomerWritten(EntityWrittenEvent $event): void
+    {
+        if ($event->getEntityName() !== 'customer') {
+            return;
+        }
+
+        $context = $event->getContext();
+        $salesChannelId = $this->enderecoService->fetchSalesChannelId($context);
+
+        if (!$this->isCrefoPayPayPalCheckEnabled($salesChannelId)) {
+            return;
+        }
+
+        foreach ($event->getIds() as $customerId) {
+            $this->processCustomer($customerId, $context);
+        }
+    }
+
+    /**
+     * Processes a single customer to set payPalExpressPayerId if needed.
+     *
+     * @param string $customerId The customer ID
+     * @param Context $context The Shopware context
+     * @return void
+     */
+    private function processCustomer(string $customerId, Context $context): void
+    {
+        $criteria = new Criteria([$customerId]);
+        $criteria->addAssociation('defaultPaymentMethod');
+
+        $customer = $this->customerRepository->search($criteria, $context)->first();
+
+        if (!$customer instanceof CustomerEntity) {
+            return;
+        }
+
+        if (!$customer->getGuest()) {
+            return;
+        }
+
+        $customFields = $customer->getCustomFields();
+        if (isset($customFields['payPalExpressPayerId']) && !empty($customFields['payPalExpressPayerId'])) {
+            return;
+        }
+
+        $defaultPaymentMethod = $customer->getDefaultPaymentMethod();
+        if (!$defaultPaymentMethod || $defaultPaymentMethod->getId() !== self::CREFO_PAY_PAYPAL_PAYMENT_METHOD_ID) {
+            return;
+        }
+
+        $payerId = $this->generatePayerId();
+
+        $this->customerRepository->update(
+            [
+                [
+                    'id' => $customerId,
+                    'customFields' => array_merge($customFields ?? [], [
+                        'payPalExpressPayerId' => $payerId,
+                    ]),
+                ],
+            ],
+            $context
+        );
+    }
+
+    private function generatePayerId(): string
+    {
+        if (isset($_SESSION['crefopay-paypal-express-transaction'])) {
+            $transactionId = $_SESSION['crefopay-paypal-express-transaction'];
+            if (!empty($transactionId)) {
+                return 'crefopay-' . $transactionId;
+            }
+        }
+
+        return 'crefopay-express';
+    }
+
+    private function isCrefoPayPayPalCheckEnabled(?string $salesChannelId): bool
+    {
+        if (!$this->enderecoService->isEnderecoPluginActive($salesChannelId)) {
+            return false;
+        }
+
+        return $this->systemConfigService->getBool(
+            self::CONFIG_KEY_CREFO_PAY_PAYPAL_CHECK,
+            $salesChannelId
+        );
+    }
+}

--- a/src/Subscriber/CrefoPayPayPalSessionProtectionSubscriber.php
+++ b/src/Subscriber/CrefoPayPayPalSessionProtectionSubscriber.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Subscriber;
+
+use Endereco\Shopware6Client\Service\EnderecoService;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Protects CrefoPay PayPal Express session from being cleared by CrefoPay's CartEventListener.
+ *
+ * CrefoPay clears PayPal Express session for paths not in allowed list (/checkout/, /widgets/, /crefo-pay/).
+ * This subscriber saves session data before CrefoPay runs (priority 100) and restores it after (priority -100).
+ * Session data is stored persistently to survive CrefoPay's cleanup.
+ */
+class CrefoPayPayPalSessionProtectionSubscriber implements EventSubscriberInterface
+{
+    private const REQUEST_ATTR_SAVED_SESSION = 'endereco_crefopay_saved_session';
+    private const SESSION_KEY_SAVED_DATA = 'endereco_crefopay_saved_session_data';
+    private const CONFIG_KEY_CREFO_PAY_PAYPAL_CHECK =
+        'EnderecoShopware6Client.config.enderecoCheckCrefoPayPayPalExpressAddress';
+
+    private SystemConfigService $systemConfigService;
+    private EnderecoService $enderecoService;
+
+    public function __construct(
+        SystemConfigService $systemConfigService,
+        EnderecoService $enderecoService
+    ) {
+        $this->systemConfigService = $systemConfigService;
+        $this->enderecoService = $enderecoService;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['saveSessionBeforeCrefoPay', 100],
+                ['restoreSessionAfterCrefoPay', -100],
+            ],
+        ];
+    }
+
+    /**
+     * Saves CrefoPay PayPal Express session data before CrefoPay's listener runs.
+     *
+     * Strategy:
+     * 1. Check if feature is enabled for the sales channel
+     * 2. Load current session data (transactionId, paypalExpressActive)
+     * 3. Restore from persistent storage if current session was cleared
+     * 4. Save to request attributes (for same request) and persistent storage (for next requests)
+     */
+    public function saveSessionBeforeCrefoPay(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+        $path = $request->getPathInfo();
+
+        if (str_starts_with($path, '/api') || str_starts_with($path, '/admin') || str_starts_with($path, '/_wdt')) {
+            return;
+        }
+
+        $salesChannelId = $this->getSalesChannelId($request);
+        if (!$this->isCrefoPayPayPalCheckEnabled($salesChannelId)) {
+            return;
+        }
+
+        if (!$request->hasSession()) {
+            return;
+        }
+
+        try {
+            $session = $request->getSession();
+            $transactionId = $session->get('crefopay-paypal-express-transaction');
+            $currentPaypalActive = $_SESSION['paypalExpressActive'] ?? null;
+            $previousSavedData = $session->get(self::SESSION_KEY_SAVED_DATA);
+
+            // Restore from persistent storage if current session was cleared
+            if ($previousSavedData && is_array($previousSavedData)) {
+                if (empty($transactionId) && !empty($previousSavedData['crefopay-paypal-express-transaction'])) {
+                    $transactionId = $previousSavedData['crefopay-paypal-express-transaction'];
+                }
+                if (empty($currentPaypalActive) && !empty($previousSavedData['paypalExpressActive'])) {
+                    $currentPaypalActive = $previousSavedData['paypalExpressActive'];
+                }
+            }
+
+            // Save if we have any session data (transactionId, paypalExpressActive, or previous saved data)
+            if (!empty($transactionId) || !empty($currentPaypalActive) || !empty($previousSavedData)) {
+                $savedData = [
+                    'crefopay-paypal-express-transaction' => $transactionId,
+                    'paypalExpressActive' => $currentPaypalActive,
+                ];
+
+                // Update persistent storage only if data changed
+                $needsUpdate = false;
+                if (!$previousSavedData || !is_array($previousSavedData)) {
+                    $needsUpdate = true;
+                } else {
+                    $oldTransactionId = $previousSavedData['crefopay-paypal-express-transaction'] ?? null;
+                    $oldPaypalActive = $previousSavedData['paypalExpressActive'] ?? null;
+
+                    if ($oldTransactionId !== $transactionId || $oldPaypalActive !== $currentPaypalActive) {
+                        $needsUpdate = true;
+                    }
+                }
+
+                // Save to request attributes for same request restoration
+                $request->attributes->set(self::REQUEST_ATTR_SAVED_SESSION, $savedData);
+
+                // Save to persistent storage for next requests
+                if ($needsUpdate) {
+                    $session->set(self::SESSION_KEY_SAVED_DATA, $savedData);
+                }
+            }
+        } catch (\RuntimeException $e) {
+            return;
+        }
+    }
+
+    /**
+     * Restores CrefoPay PayPal Express session data after CrefoPay's listener runs.
+     *
+     * Strategy:
+     * 1. Load saved data from request attributes (same request) or persistent storage (previous requests)
+     * 2. Restore session values (transactionId, paypalExpressActive) if they were cleared
+     * 3. Works for all paths, not just /checkout/confirm, to protect session during address validation
+     * 4. Clears session data on /checkout/order or / (homepage) as checkout is complete
+     */
+    public function restoreSessionAfterCrefoPay(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+        $path = $request->getPathInfo();
+
+        if (str_starts_with($path, '/api') || str_starts_with($path, '/admin') || str_starts_with($path, '/_wdt')) {
+            return;
+        }
+
+        $salesChannelId = $this->getSalesChannelId($request);
+        if (!$this->isCrefoPayPayPalCheckEnabled($salesChannelId)) {
+            return;
+        }
+
+        // Clear session data on checkout completion or homepage
+        if ($path === '/checkout/order' || $path === '/') {
+            $this->clearSessionData($request);
+            return;
+        }
+
+        // Try to load from request attributes first (same request), then from persistent storage
+        $savedData = $request->attributes->get(self::REQUEST_ATTR_SAVED_SESSION);
+
+        if ((!$savedData || !is_array($savedData)) && $request->hasSession()) {
+            try {
+                $session = $request->getSession();
+                $savedData = $session->get(self::SESSION_KEY_SAVED_DATA);
+            } catch (\RuntimeException $e) {
+                return;
+            }
+        }
+
+        if (!$savedData || !is_array($savedData)) {
+            return;
+        }
+
+        if (!$request->hasSession()) {
+            return;
+        }
+
+        try {
+            $session = $request->getSession();
+
+            // Restore session values if they were cleared by CrefoPay
+            if (isset($savedData['crefopay-paypal-express-transaction'])) {
+                $session->set('crefopay-paypal-express-transaction', $savedData['crefopay-paypal-express-transaction']);
+            }
+
+            if (isset($savedData['paypalExpressActive'])) {
+                $_SESSION['paypalExpressActive'] = $savedData['paypalExpressActive'];
+            }
+
+            // Update persistent storage if needed
+            $currentPersistentData = $session->get(self::SESSION_KEY_SAVED_DATA);
+            if (!empty($savedData) && $currentPersistentData !== $savedData) {
+                $session->set(self::SESSION_KEY_SAVED_DATA, $savedData);
+            }
+        } catch (\RuntimeException $e) {
+            return;
+        }
+    }
+
+    /**
+     * Clears CrefoPay PayPal Express session data.
+     *
+     * Called when checkout is complete (/checkout/order) or user returns to homepage (/).
+     * Removes all session variables and persistent storage related to CrefoPay PayPal Express.
+     */
+    private function clearSessionData(Request $request): void
+    {
+        if (!$request->hasSession()) {
+            return;
+        }
+
+        try {
+            $session = $request->getSession();
+
+            // Clear session variables
+            $session->remove('crefopay-paypal-express-transaction');
+            if (isset($_SESSION['paypalExpressActive'])) {
+                unset($_SESSION['paypalExpressActive']);
+            }
+
+            // Clear persistent storage
+            $session->remove(self::SESSION_KEY_SAVED_DATA);
+
+            // Clear request attributes
+            $request->attributes->remove(self::REQUEST_ATTR_SAVED_SESSION);
+        } catch (\RuntimeException $e) {
+            return;
+        }
+    }
+
+    private function getSalesChannelId(Request $request): ?string
+    {
+        $salesChannelId = $request->attributes->get('sw-sales-channel-id');
+        if ($salesChannelId) {
+            return (string) $salesChannelId;
+        }
+
+        return null;
+    }
+
+    private function isCrefoPayPayPalCheckEnabled(?string $salesChannelId): bool
+    {
+        if (!$this->enderecoService->isEnderecoPluginActive($salesChannelId)) {
+            return false;
+        }
+
+        return $this->systemConfigService->getBool(
+            self::CONFIG_KEY_CREFO_PAY_PAYPAL_CHECK,
+            $salesChannelId
+        );
+    }
+}

--- a/src/Subscriber/CrefoPayPayPalSessionProtectionSubscriber.php
+++ b/src/Subscriber/CrefoPayPayPalSessionProtectionSubscriber.php
@@ -145,28 +145,6 @@ class CrefoPayPayPalSessionProtectionSubscriber implements EventSubscriberInterf
             return;
         }
 
-        // Clear session data on checkout completion or homepage
-        if ($path === '/checkout/order' || $path === '/') {
-            $this->clearSessionData($request);
-            return;
-        }
-
-        // Try to load from request attributes first (same request), then from persistent storage
-        $savedData = $request->attributes->get(self::REQUEST_ATTR_SAVED_SESSION);
-
-        if ((!$savedData || !is_array($savedData)) && $request->hasSession()) {
-            try {
-                $session = $request->getSession();
-                $savedData = $session->get(self::SESSION_KEY_SAVED_DATA);
-            } catch (\RuntimeException $e) {
-                return;
-            }
-        }
-
-        if (!$savedData || !is_array($savedData)) {
-            return;
-        }
-
         if (!$request->hasSession()) {
             return;
         }
@@ -174,7 +152,25 @@ class CrefoPayPayPalSessionProtectionSubscriber implements EventSubscriberInterf
         try {
             $session = $request->getSession();
 
+            // Try to load from request attributes first (same request), then from persistent storage
+            $savedData = $request->attributes->get(self::REQUEST_ATTR_SAVED_SESSION);
+
+            if (!$savedData || !is_array($savedData)) {
+                $savedData = $session->get(self::SESSION_KEY_SAVED_DATA);
+            }
+
+            if (!$savedData || !is_array($savedData)) {
+                return;
+            }
+
+            // Clear session data on checkout completion or homepage (only if we have session data)
+            if ($path === '/checkout/order' || $path === '/') {
+                $this->clearSessionData($request);
+                return;
+            }
+
             // Restore session values if they were cleared by CrefoPay
+            // Note: paypalExpressActive uses $_SESSION as it's used directly by CrefoPay
             if (isset($savedData['crefopay-paypal-express-transaction'])) {
                 $session->set('crefopay-paypal-express-transaction', $savedData['crefopay-paypal-express-transaction']);
             }
@@ -183,7 +179,6 @@ class CrefoPayPayPalSessionProtectionSubscriber implements EventSubscriberInterf
                 $_SESSION['paypalExpressActive'] = $savedData['paypalExpressActive'];
             }
 
-            // Update persistent storage if needed
             $currentPersistentData = $session->get(self::SESSION_KEY_SAVED_DATA);
             if (!empty($savedData) && $currentPersistentData !== $savedData) {
                 $session->set(self::SESSION_KEY_SAVED_DATA, $savedData);
@@ -208,16 +203,12 @@ class CrefoPayPayPalSessionProtectionSubscriber implements EventSubscriberInterf
         try {
             $session = $request->getSession();
 
-            // Clear session variables
             $session->remove('crefopay-paypal-express-transaction');
             if (isset($_SESSION['paypalExpressActive'])) {
                 unset($_SESSION['paypalExpressActive']);
             }
 
-            // Clear persistent storage
             $session->remove(self::SESSION_KEY_SAVED_DATA);
-
-            // Clear request attributes
             $request->attributes->remove(self::REQUEST_ATTR_SAVED_SESSION);
         } catch (\RuntimeException $e) {
             return;


### PR DESCRIPTION
CrefoPay's CartEventListener clears PayPal Express session for paths not in allowed list, breaking checkout flow when session data is needed. This prevents proper identification of PayPal Express addresses and breaks guest customer enrichment with payer ID.

This change adds session protection that saves session data before CrefoPay runs and restores it after, ensuring session survives throughout checkout. Session data is stored persistently to survive cleanup between requests. Guest customers created via CrefoPay PayPal Express checkout are enriched with payPalExpressPayerId custom field based on transaction ID from session, allowing Endereco to properly identify these addresses as PayPal Express addresses.

Also fixes type error when salesChannelId is null by updating isEnderecoPluginActive to accept nullable string parameter.