### PR TITLE
Adjust endereco_data_marker selectors when ACRIS is active

### DIFF
--- a/src/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Resources/views/storefront/component/address/address-form.html.twig
@@ -26,15 +26,22 @@
                         data-subdivision-code-selector="[name='{{ prefix }}[countryStateId]']"
                         data-postal-code-selector="[name='{{ prefix }}[zipcode]']"
                         data-locality-selector="[name='{{ prefix }}[city]']"
-                        data-street-full-selector="[name='{{ prefix }}[street]']"
+                        {% if not enderecoIsAcrisStreetActive() %}
+                            data-street-full-selector="[name='{{ prefix }}[street]']"
+                        {% endif %}
                         {% if page.endereco_config.hasAnyAdditionalFields %}
                             data-additional-info-selector="[name='{{ prefix }}[{{ page.endereco_config.additionalInfoFieldName }}]']"
                         {% endif %}
                         data-ams-status-selector="[name='{{ prefix }}[amsStatus]']"
                         data-ams-timestamp-selector="[name='{{ prefix }}[amsTimestamp]']"
                         data-ams-predictions-selector="[name='{{ prefix }}[amsPredictions]']"
-                        data-street-selector="[name='{{ prefix }}[enderecoStreet]']"
-                        data-house-number-selector="[name='{{ prefix }}[enderecoHousenumber]']"
+                        {% if enderecoIsAcrisStreetActive() %}
+                            data-street-selector="[name='{{ prefix }}[street]']"
+                            data-house-number-selector="[name='{{ prefix }}[houseNumber]']"
+                        {% else %}
+                            data-street-selector="[name='{{ prefix }}[enderecoStreet]']"
+                            data-house-number-selector="[name='{{ prefix }}[enderecoHousenumber]']"
+                        {% endif %}
                         data-address-type="{{ addressType }}"
                         data-intent="{{ enderecoIntent is defined ? enderecoIntent : 'edit' }}"
                 >


### PR DESCRIPTION
When the ACRIS Separate Street  plugin is active, Endereco's split-field overrides
are disabled, meaning the default CSS selectors for enderecoStreet and
enderecoHousenumber point to non-existent elements. Furthermore, the standard
street field, which usually contains the full address, is repurposed by ACRIS to hold
only the street name. This causes the AMS  to validate incomplete address data, as
it can no longer correctly locate the input values for street and house number.

address-form.html.twig was updated to conditionally assign data-selectors based
on ACRIS's activation state:
- ACRIS active:  data-street-selector now points to the standard street field,
  data-house-number-selector points to houseNumber, and the data-street-full-selector
  is omitted (as no combined street field exists).
- ACRIS inactive: As before, data-street-selector and data-house-number-selector
  are set to Endereco's default split-fields (enderecoStreet / enderecoHousenumber )
  and the data-street-full-selector is set to the standard street field.

This ensures that the JavaScript SDK monitors the correct input fields and sends complete
address data (name + number) to the API, even when ACRIS has modified the default form structure.

Ref: DEV-482

The changes were tested locally (shopware6-dev-env) and on our qa testshop.