### PR TITLE
Skip enderecos validation modifier when ACRIS is active

### DIFF
--- a/src/Resources/config/services/subscriber.php
+++ b/src/Resources/config/services/subscriber.php
@@ -16,6 +16,7 @@ use Endereco\Shopware6Client\Service\EnderecoService;
 use Endereco\Shopware6Client\Service\EnderecoService\AgentInfoGeneratorInterface;
 use Endereco\Shopware6Client\Service\SessionManagementService;
 use Endereco\Shopware6Client\Service\EnderecoService\PluginVersionFetcherInterface;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Endereco\Shopware6Client\Service\OrderAddressToCustomerAddressDataMatcherInterface;
 use Endereco\Shopware6Client\Service\OrdersCustomFieldsUpdaterInterface;
 use Endereco\Shopware6Client\Service\ProcessContextService;
@@ -70,6 +71,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$countryCodeFetcher' => service(CountryCodeFetcherInterface::class),
             '$customerAddressIntegrityInsurance' => service(CustomerAddressIntegrityInsuranceInterface::class),
             '$requestStack' => service('request_stack'),
+            '$pluginStatusService' => service(PluginStatusService::class),
         ])
         ->tag('kernel.event_subscriber');
 

--- a/src/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Subscriber/CustomerAddressSubscriber.php
@@ -11,6 +11,7 @@ use Endereco\Shopware6Client\Service\AddressCheck\AddressCheckPayloadBuilderInte
 use Endereco\Shopware6Client\Service\AddressCheck\CountryCodeFetcherInterface;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddressIntegrityInsuranceInterface;
 use Endereco\Shopware6Client\Service\EnderecoService;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Endereco\Shopware6Client\Service\ProcessContextService;
 use Endereco\Shopware6Client\Service\SessionManagementService;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
@@ -71,6 +72,8 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
 
     protected RequestStack $requestStack;
 
+    protected PluginStatusService $pluginStatusService;
+
     private AddressCheckPayloadBuilderInterface $addressCheckPayloadBuilder;
 
     private ProcessContextService $processContext;
@@ -95,7 +98,8 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
         EntityRepository $countryStateRepository,
         CountryCodeFetcherInterface $countryCodeFetcher,
         CustomerAddressIntegrityInsuranceInterface $customerAddressIntegrityInsurance,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        PluginStatusService $pluginStatusService
     ) {
         $this->processContext = $processContext;
         $this->addressCheckPayloadBuilder = $addressCheckPayloadBuilder;
@@ -110,6 +114,7 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
         $this->countryCodeFetcher = $countryCodeFetcher;
         $this->customerAddressIntegrityInsurance = $customerAddressIntegrityInsurance;
         $this->requestStack = $requestStack;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     /**
@@ -318,6 +323,11 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
      */
     public function modifyValidationConstraints(BuildValidationEvent $event): void
     {
+        // Break execution if AcrisSeparateStreetCS plugin is active
+        if ($this->pluginStatusService->isAcrisStreetActive()) {
+            return;
+        }
+
         // Fetch context and sales channel ID
         $context = $event->getContext();
         $salesChannelId = $this->enderecoService->fetchSalesChannelId($context);


### PR DESCRIPTION
When the ACRIS plugin is active, Endereco's custom address fields are no longer rendered in the frontend. However, the CustomerAddressSubscriber still attempts to modify validation constraints by adding NotBlank requirements to non-existent Endereco fields (enderecoStreet, enderecoHousenumber) and marking the standard street field as optional. This can lead to validation errors or incorrect validation logic, as ACRIS requires the standard street field to be mandatory.

To address this issue, the following changes werde made:
- an early exit was implemented in the modifyValidationConstraints method within the CustomerAddressSubscriber.php. If the ACRIS street override is detected as active, the subscriber now skips its custom constraint modifications completely, allowing Shopware and ACRIS to handle the validation natively.
-  in subscriber.php the dependency injection for CustomerAddressSubscriber was updated to include the PluginStatusService, that provides the isAcrisStreetActive function.

Ref: DEV-483

The changes were tested manually in sw6-dev-env. 