### PR TITLE
Ensure deterministic subscriber execution and prevent extension overwriting

### DIFF
--- a/src/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Subscriber/CustomerAddressSubscriber.php
@@ -155,10 +155,11 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
 
         // These events are used to extend the data that are used when an address is written.
         // This is a place to manipulate the data before the address entity is written.
+        // Priority was set to -1000 to ensure endereco hopefully runs after all other listeners.
         $beforeAddressWritingEvents = [
-            CustomerEvents::MAPPING_ADDRESS_CREATE => ['addMissingDataToAddressMapping'],
-            CustomerEvents::MAPPING_REGISTER_ADDRESS_BILLING => ['addMissingDataToAddressMapping'],
-            CustomerEvents::MAPPING_REGISTER_ADDRESS_SHIPPING => ['addMissingDataToAddressMapping'],
+            CustomerEvents::MAPPING_ADDRESS_CREATE => ['addMissingDataToAddressMapping', -1000],
+            CustomerEvents::MAPPING_REGISTER_ADDRESS_BILLING => ['addMissingDataToAddressMapping', -1000],
+            CustomerEvents::MAPPING_REGISTER_ADDRESS_SHIPPING => ['addMissingDataToAddressMapping', -1000],
         ];
 
         // This event is used after the address has been written to the database.
@@ -421,16 +422,20 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
             $predictions = json_decode($input->get('amsPredictions'), true) ?? [];
         }
 
+        // Initialize extensions array if it does not exist or is not an array, to avoid
+        // errors when adding endereco extension data.
+        if (!isset($output['extensions']) || !is_array($output['extensions'])) {
+            $output['extensions'] = [];
+        }
+
         // Add relevant endereco data.
-        $output['extensions'] = [
-            CustomerAddressExtension::ENDERECO_EXTENSION => [
-                'street' => $input->get('enderecoStreet', ''),
-                'houseNumber' => $input->get('enderecoHousenumber', ''),
-                'amsStatus' => $input->get('amsStatus') ?? EnderecoBaseAddressExtensionEntity::AMS_STATUS_NOT_CHECKED,
-                'amsTimestamp' => (int) $input->get('amsTimestamp', 0),
-                'amsPredictions' => $predictions,
-                'isPayPalAddress' => false // We will calculate it later.
-            ]
+        $output['extensions'][CustomerAddressExtension::ENDERECO_EXTENSION] = [
+            'street' => $input->get('enderecoStreet', ''),
+            'houseNumber' => $input->get('enderecoHousenumber', ''),
+            'amsStatus' => $input->get('amsStatus') ?? EnderecoBaseAddressExtensionEntity::AMS_STATUS_NOT_CHECKED,
+            'amsTimestamp' => (int) $input->get('amsTimestamp', 0),
+            'amsPredictions' => $predictions,
+            'isPayPalAddress' => false // We will calculate it later.
         ];
 
         // Make sure the default street and endereco street name and house number are synchronized.


### PR DESCRIPTION
The CustomerAddressSubscriber currently operates with a default priority (0) on address mapping events. Since other plugins (like ACRIS) use the same priority, the execution order is undefined. This leads to inconsistent street data processing. Furthermore, the subscriber currently overwrites the entire $output['extensions'] array instead of targeting only its own data, which causes silent data loss for other plugins, that have already written to that structure.

To address this issues these changes were made in CustomerAddressSubscriber.php:
- Set an explicit priority of -1000 for the listeners on MAPPING_ADDRESS_CREATE, MAPPING_REGISTER_ADDRESS_BILLING, and MAPPING_REGISTER_ADDRESS_SHIPPING to ensure Endereco always runs last, at least after ACRIS, which uses default priority 0.
- Refactored the logic in CustomerAddressSubscriber.php to only modify the enderecoAddress key within the extensions array. This ensures that existing extension data from other plugins remains untouched.

Ref: DEV-485

Verified in sw6-dev-env using the Endereco Harness Plugin. Tests confirmed that the priority-based
execution is reliable and that data written by other plugins is preserved when Endereco runs last.