### PR TITLE
Populate Endereco extension from ACRIS input during form submission

### DIFF
--- a/src/Controller/Storefront/AddressController.php
+++ b/src/Controller/Storefront/AddressController.php
@@ -11,6 +11,7 @@ use Endereco\Shopware6Client\Model\EnderecoExtensionData;
 use Endereco\Shopware6Client\Service\AddressCheck\AddressCheckPayloadBuilderInterface;
 use Endereco\Shopware6Client\Service\EnderecoService;
 use Endereco\Shopware6Client\Service\SessionManagementService;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Exception;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
@@ -48,19 +49,24 @@ class AddressController extends StorefrontController
 
     protected SessionManagementService $sessionManagementService;
 
+    protected PluginStatusService $pluginStatusService;
+
     /**
      * @param EntityRepository<CustomerAddressCollection> $addressRepository
+     * @param PluginStatusService $pluginStatusService
      */
     public function __construct(
         EnderecoService $enderecoService,
         SessionManagementService $sessionManagementService,
         EntityRepository $addressRepository,
-        AddressCheckPayloadBuilderInterface $addressCheckPayloadBuilder
+        AddressCheckPayloadBuilderInterface $addressCheckPayloadBuilder,
+        PluginStatusService $pluginStatusService
     ) {
         $this->enderecoService = $enderecoService;
         $this->sessionManagementService = $sessionManagementService;
         $this->addressRepository = $addressRepository;
         $this->addressCheckPayloadBuilder = $addressCheckPayloadBuilder;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     /**
@@ -150,10 +156,25 @@ class AddressController extends StorefrontController
         $payload->setCountryId($address['countryId'] ?? null);
         $payload->setCountryStateId(!empty($address['countryStateId']) ? $address['countryStateId'] : null);
         
+        $enderecoStreet = $address['enderecoStreet'] ?? '';
+        $enderecoHouseNumber = $address['enderecoHousenumber'] ?? '';
+        $skipSyncStreet = false;
+
+        if ($this->pluginStatusService->isAcrisStreetActive()) {
+            $acrisHouseNumber = $address['houseNumber'] ?? '';
+            if ($acrisHouseNumber !== '') {
+                $payload->setStreet(($address['street'] ?? '') . ' ' . $acrisHouseNumber);
+                $enderecoStreet = $address['street'] ?? '';
+                $enderecoHouseNumber = $acrisHouseNumber;
+                // ACRIS already successfully divided the address, skip endereco splitting.
+                $skipSyncStreet = true;
+            }
+        }
+
         $extensionData = new EnderecoExtensionData();
-        $extensionData->setStreet($address['enderecoStreet'] ?? '')
-            ->setHouseNumber($address['enderecoHousenumber'] ?? '')
-            ->setAmsStatus($address['amsStatus'])
+        $extensionData->setStreet($enderecoStreet)
+            ->setHouseNumber($enderecoHouseNumber)
+            ->setAmsStatus($address['amsStatus'] ?? '')
             ->setAmsPredictions($predictions)
             ->setAmsTimestamp(time());
         
@@ -162,7 +183,9 @@ class AddressController extends StorefrontController
         $updatePayload = $payload->toArray();
 
         // Make sure that custom "street name" and "house number" are filled or the default "street" is filled.
-        $this->enderecoService->syncStreet($updatePayload, $mainContext, $salesChannelId);
+        if (!$skipSyncStreet) {
+            $this->enderecoService->syncStreet($updatePayload, $mainContext, $salesChannelId);
+        }
 
         // Calculate payload
         $payloadBody = $this->addressCheckPayloadBuilder->buildFromArray(
@@ -173,7 +196,9 @@ class AddressController extends StorefrontController
                 'city' => $updatePayload['city'],
                 'street' => $updatePayload['street'],
                 'additionalAddressLine1' => $updatePayload['additionalAddressLine1'],
-                'additionalAddressLine2' => $updatePayload['additionalAddressLine2']
+                'additionalAddressLine2' => $updatePayload['additionalAddressLine2'],
+                'enderecoStreet' => $enderecoStreet,
+                'enderecoHousenumber' => $enderecoHouseNumber
             ],
             $mainContext
         );

--- a/src/Resources/config/services/controller.php
+++ b/src/Resources/config/services/controller.php
@@ -37,6 +37,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$sessionManagementService' => service(SessionManagementService::class),
             '$addressRepository' => service('customer_address.repository'),
             '$addressCheckPayloadBuilder' => service(AddressCheckPayloadBuilderInterface::class),
+            '$pluginStatusService' => service(\Endereco\Shopware6Client\Service\PluginStatusService::class),
         ])
         ->call('setContainer', [
             service('service_container')

--- a/src/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Subscriber/CustomerAddressSubscriber.php
@@ -428,10 +428,24 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
             $output['extensions'] = [];
         }
 
+        $enderecoStreet = (string)$input->get('enderecoStreet', '');
+        $enderecoHouseNumber = (string)$input->get('enderecoHousenumber', '');
+        $skipSyncStreet = false;
+
+        if ($this->pluginStatusService->isAcrisStreetActive()) {
+            $acrisHouseNumber = (string)$input->get('houseNumber', '');
+            if ($acrisHouseNumber !== '') {
+                $enderecoStreet = (string)$input->get('street', '');
+                $enderecoHouseNumber = $acrisHouseNumber;
+                // ACRIS already successfully divided the address, skip endereco splitting.
+                $skipSyncStreet = true;
+            }
+        }
+
         // Add relevant endereco data.
         $output['extensions'][CustomerAddressExtension::ENDERECO_EXTENSION] = [
-            'street' => $input->get('enderecoStreet', ''),
-            'houseNumber' => $input->get('enderecoHousenumber', ''),
+            'street' => $enderecoStreet,
+            'houseNumber' => $enderecoHouseNumber,
             'amsStatus' => $input->get('amsStatus') ?? EnderecoBaseAddressExtensionEntity::AMS_STATUS_NOT_CHECKED,
             'amsTimestamp' => (int) $input->get('amsTimestamp', 0),
             'amsPredictions' => $predictions,
@@ -439,7 +453,9 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
         ];
 
         // Make sure the default street and endereco street name and house number are synchronized.
-        $this->enderecoService->syncStreet($output, $context, $salesChannelId);
+        if (!$skipSyncStreet) {
+            $this->enderecoService->syncStreet($output, $context, $salesChannelId);
+        }
 
         // Calculate payload
         $payloadBody = $this->addressCheckPayloadBuilder->buildFromArray(


### PR DESCRIPTION
The Endereco subscriber for the three DataMappingEvents (MAPPING_ADDRESS_CREATE, MAPPING_REGISTER_ADDRESS_BILLING, MAPPING_REGISTER_ADDRESS_SHIPPING) usually reads the address data directly from the enderecoStreet and enderecoHousenumber fields in the submitted input.

However, when the ACRIS plugin is active, it redefines the form fields, and these specific Endereco keys are missing. Instead, ACRIS uses street (redefined to street name only) and houseNumber. As a result, the subscriber and the AddressController fail to populate the Endereco address extension correctly.

To address this issue the following changes were made: Modified CustomerAddressSubscriber.php and AddressController.php to detect if ACRIS is active via the PluginStatusService. If active and ACRIS keys are present in the input:
- The street and house number are read directly from ACRIS's street and houseNumber fields.
- These values are written into the enderecoAddress extension.
- The syncStreet() method is skipped, as the address split provided by ACRIS is considered authoritative.
- Existing AMS status fields (status, timestamp, predictions) remain unaffected.

The PluginStatusService was also injected into the AddressController via controller.php to enable this check.

The reading and writing operations were tested and logged in sw6-dev-env. These provided log files cover
normal payments, PayPal Payments, and Existing Customer Checks, with/without ACRIS and with/without
endereco split.
[controller.log](https://github.com/user-attachments/files/27535919/controller.log)
[subscriber.log](https://github.com/user-attachments/files/27535921/subscriber.log)
