### PR TITLE
Mirror server-side changes to endereco's extension in ACRIS custom fields

### DIFF
--- a/src/Model/AcrisCustomField.php
+++ b/src/Model/AcrisCustomField.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Model;
+
+class AcrisCustomField
+{
+    public const STREET = 'acris_separate_street_address_street';
+    public const HOUSE_NUMBER = 'acris_separate_street_address_house_number';
+}

--- a/src/Model/AddressPersistenceStrategy/PersistNativeAndExtensionFields.php
+++ b/src/Model/AddressPersistenceStrategy/PersistNativeAndExtensionFields.php
@@ -10,8 +10,10 @@ use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\End
 use Endereco\Shopware6Client\Model\CustomerAddressPersistenceStrategy;
 use Endereco\Shopware6Client\Model\CustomerAddressUpdatePayload;
 use Endereco\Shopware6Client\Model\CustomerAddressField;
+use Endereco\Shopware6Client\Model\AcrisCustomField;
 use Endereco\Shopware6Client\Service\CustomerAddressEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoExtensionEntityUpdater;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Endereco\Shopware6Client\Model\EnderecoExtensionData;
 use Endereco\Shopware6Client\Service\AddressCheck\AdditionalAddressFieldCheckerInterface;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
@@ -36,6 +38,7 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
     private Context $context;
     private CustomerAddressEntityUpdater $entityUpdater;
     private EnderecoExtensionEntityUpdater $extensionEntityUpdater;
+    private PluginStatusService $pluginStatusService;
 
     /**
      * @param AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker
@@ -49,7 +52,8 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
         EntityRepository $customerAddressExtensionRepository,
         Context $context,
         CustomerAddressEntityUpdater $entityUpdater,
-        EnderecoExtensionEntityUpdater $extensionEntityUpdater
+        EnderecoExtensionEntityUpdater $extensionEntityUpdater,
+        PluginStatusService $pluginStatusService
     )
     {
         $this->additionalAddressFieldChecker = $additionalAddressFieldChecker;
@@ -58,6 +62,7 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
         $this->context = $context;
         $this->entityUpdater = $entityUpdater;
         $this->extensionEntityUpdater = $extensionEntityUpdater;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     public function execute(
@@ -78,9 +83,25 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
             throw new \RuntimeException('Address entity cannot be null');
         }
 
-        $this->maybeUpdateNative(
-            $normalizedStreetFull,  $normalizedAdditionalInfo, $addressEntity
+        $payload = new CustomerAddressUpdatePayload($addressEntity->getId());
+        $isNativeChanged = $this->maybeUpdateNative(
+            $normalizedStreetFull,
+            $normalizedAdditionalInfo,
+            $addressEntity,
+            $payload
         );
+
+        $isCustomFieldsChanged = $this->maybeUpdateCustomFields(
+            $streetName,
+            $buildingNumber,
+            $addressEntity,
+            $payload
+        );
+
+        if ($isNativeChanged || $isCustomFieldsChanged) {
+            $this->addressRepository->update([$payload->toArray()], $this->context);
+            $this->entityUpdater->updateFromPayload($payload, $addressEntity);
+        }
 
         $this->maybeUpdateExtension(
             $streetName,
@@ -95,41 +116,39 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
      * @param string $streetFull Complete street address
      * @param string|null $additionalInfo Additional address information
      * @param CustomerAddressEntity $addressEntity Address entity to update
+     * @param CustomerAddressUpdatePayload $payload Payload to populate
      *
-     * @return void
+     * @return bool True if native fields have changed
      */
-    private function maybeUpdateNative(string $streetFull, ?string $additionalInfo, CustomerAddressEntity $addressEntity): void
-    {
+    private function maybeUpdateNative(
+        string $streetFull,
+        ?string $additionalInfo,
+        CustomerAddressEntity $addressEntity,
+        CustomerAddressUpdatePayload $payload
+    ): bool {
         if (!$this->areValuesChanged($streetFull, $additionalInfo, $addressEntity)) {
-            return;
+            return false;
         }
 
-        // Update in DB
-        $payload = $this->buildNativeUpdatePayload($streetFull, $additionalInfo, $addressEntity);
-        $this->addressRepository->update([$payload->toArray()], $this->context);
+        $payload = $this->buildNativeUpdatePayload($streetFull, $additionalInfo, $payload);
 
-        // Update in memory using normalized payload data
-        $this->entityUpdater->updateFromPayload($payload, $addressEntity);
+        return true;
     }
-
-
-
 
     /**
      * Builds the payload for updating native Shopware address fields
      *
      * @param string $streetFull Complete street address
      * @param string|null $additionalInfo Additional address information
-     * @param CustomerAddressEntity $addressEntity Address entity being updated
+     * @param CustomerAddressUpdatePayload $payload Update payload for the address repository
      *
-     * @return CustomerAddressUpdatePayload Update payload for the address repository
+     * @return CustomerAddressUpdatePayload
      */
     private function buildNativeUpdatePayload(
         string $streetFull,
         ?string $additionalInfo,
-        CustomerAddressEntity $addressEntity
+        CustomerAddressUpdatePayload $payload
     ): CustomerAddressUpdatePayload {
-        $payload = new CustomerAddressUpdatePayload($addressEntity->getId());
         $payload->setStreet($streetFull);
 
         if ($this->additionalAddressFieldChecker->hasAdditionalAddressField($this->context)) {
@@ -142,6 +161,62 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
         }
 
         return $payload;
+    }
+
+    /**
+     * Updates the custom fields in the payload if ACRIS values have changed
+     *
+     * @param string $streetName Street name
+     * @param string $buildingNumber Building number
+     * @param CustomerAddressEntity $addressEntity Address entity to update
+     * @param CustomerAddressUpdatePayload $payload Payload to populate
+     *
+     * @return bool True if custom fields have changed
+     */
+    private function maybeUpdateCustomFields(
+        string $streetName,
+        string $buildingNumber,
+        CustomerAddressEntity $addressEntity,
+        CustomerAddressUpdatePayload $payload
+    ): bool {
+        if (!$this->pluginStatusService->isAcrisStreetActive()) {
+            return false;
+        }
+
+        if (!$this->areCustomFieldsChanged($streetName, $buildingNumber, $addressEntity)) {
+            return false;
+        }
+
+        $currentCustomFields = $addressEntity->getCustomFields() ?? [];
+        $newCustomFields = array_merge($currentCustomFields, [
+            AcrisCustomField::STREET => $streetName,
+            AcrisCustomField::HOUSE_NUMBER => $buildingNumber,
+        ]);
+
+        $payload->setCustomFields($newCustomFields);
+
+        return true;
+    }
+
+    /**
+     * Checks if ACRIS custom fields have changed
+     *
+     * @param string $streetName New street name
+     * @param string $buildingNumber New building number
+     * @param CustomerAddressEntity $addressEntity The address entity to check against
+     *
+     * @return bool True if any custom values have changed
+     */
+    private function areCustomFieldsChanged(
+        string $streetName,
+        string $buildingNumber,
+        CustomerAddressEntity $addressEntity
+    ): bool {
+        $currentCustomFields = $addressEntity->getCustomFields() ?? [];
+        $acrisStreet = $currentCustomFields[AcrisCustomField::STREET] ?? null;
+        $acrisHouseNo = $currentCustomFields[AcrisCustomField::HOUSE_NUMBER] ?? null;
+
+        return $acrisStreet !== $streetName || $acrisHouseNo !== $buildingNumber;
     }
 
     /**
@@ -198,7 +273,7 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
             ->setAddressId($addressExtension->getAddressId())
             ->setStreet($streetName)
             ->setHouseNumber($buildingNumber);
-        
+
         $this->extensionRepository->update([$extensionData->toArray()], $this->context);
 
         // Update in memory using normalized payload data

--- a/src/Model/AddressPersistenceStrategy/PersistOnlyExtensionFields.php
+++ b/src/Model/AddressPersistenceStrategy/PersistOnlyExtensionFields.php
@@ -10,6 +10,12 @@ use Endereco\Shopware6Client\Model\CustomerAddressPersistenceStrategy;
 use Endereco\Shopware6Client\Model\EnderecoExtensionData;
 use Endereco\Shopware6Client\Service\EnderecoExtensionEntityUpdater;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
+use Endereco\Shopware6Client\Model\AcrisCustomField;
+use Endereco\Shopware6Client\Model\CustomerAddressUpdatePayload;
+use Endereco\Shopware6Client\Service\CustomerAddressEntityUpdater;
+use Endereco\Shopware6Client\Service\PluginStatusService;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 
@@ -21,18 +27,32 @@ final class PersistOnlyExtensionFields implements CustomerAddressPersistenceStra
     private Context $context;
     private EnderecoExtensionEntityUpdater $extensionEntityUpdater;
 
+    /** @var EntityRepository<CustomerAddressCollection> */
+    private EntityRepository $addressRepository;
+
+    private CustomerAddressEntityUpdater $entityUpdater;
+
+    private PluginStatusService $pluginStatusService;
+
     /**
      * @param EntityRepository<EnderecoCustomerAddressExtensionCollection> $customerAddressExtensionRepository
+     * @param EntityRepository<CustomerAddressCollection> $customerAddressRepository
      */
     public function __construct(
         EntityRepository $customerAddressExtensionRepository,
         Context $context,
-        EnderecoExtensionEntityUpdater $extensionEntityUpdater
+        EnderecoExtensionEntityUpdater $extensionEntityUpdater,
+        EntityRepository $customerAddressRepository,
+        CustomerAddressEntityUpdater $entityUpdater,
+        PluginStatusService $pluginStatusService
     )
     {
         $this->extensionRepository = $customerAddressExtensionRepository;
         $this->context = $context;
         $this->extensionEntityUpdater = $extensionEntityUpdater;
+        $this->addressRepository = $customerAddressRepository;
+        $this->entityUpdater = $entityUpdater;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     /**
@@ -51,10 +71,21 @@ final class PersistOnlyExtensionFields implements CustomerAddressPersistenceStra
         string $buildingNumber,
         CustomerAddressDTO $customerAddressDTO
     ): void {
+        $addressEntity = $customerAddressDTO->getCustomerAddress();
         $addressExtension = $customerAddressDTO->getEnderecoCustomerAddressExtension();
         if ($addressExtension === null) {
             throw new \RuntimeException('Address extension cannot be null');
         }
+
+        if ($addressEntity === null) {
+            throw new \RuntimeException('Address entity cannot be null');
+        }
+
+        $this->maybeUpdateCustomFields(
+            $streetName,
+            $buildingNumber,
+            $addressEntity
+        );
 
         $this->maybeUpdateExtension(
             $streetName,
@@ -85,7 +116,7 @@ final class PersistOnlyExtensionFields implements CustomerAddressPersistenceStra
             ->setAddressId($addressExtension->getAddressId())
             ->setStreet($streetName)
             ->setHouseNumber($buildingNumber);
-        
+
         $this->extensionRepository->update([$extensionData->toArray()], $this->context);
 
         // Update in memory using normalized payload data
@@ -115,5 +146,61 @@ final class PersistOnlyExtensionFields implements CustomerAddressPersistenceStra
         }
 
         return false;
+    }
+
+    /**
+     * Updates the custom fields in the payload if ACRIS values have changed
+     *
+     * @param string $streetName Street name
+     * @param string $buildingNumber Building number
+     * @param CustomerAddressEntity $addressEntity Address entity to update
+     *
+     * @return void
+     */
+    private function maybeUpdateCustomFields(
+        string $streetName,
+        string $buildingNumber,
+        CustomerAddressEntity $addressEntity
+    ): void {
+        if (!$this->pluginStatusService->isAcrisStreetActive()) {
+            return;
+        }
+
+        if (!$this->areCustomFieldsChanged($streetName, $buildingNumber, $addressEntity)) {
+            return;
+        }
+
+        $currentCustomFields = $addressEntity->getCustomFields() ?? [];
+        $newCustomFields = array_merge($currentCustomFields, [
+            AcrisCustomField::STREET => $streetName,
+            AcrisCustomField::HOUSE_NUMBER => $buildingNumber,
+        ]);
+
+        $payload = new CustomerAddressUpdatePayload($addressEntity->getId());
+        $payload->setCustomFields($newCustomFields);
+
+        $this->addressRepository->update([$payload->toArray()], $this->context);
+        $this->entityUpdater->updateFromPayload($payload, $addressEntity);
+    }
+
+    /**
+     * Checks if ACRIS custom fields have changed
+     *
+     * @param string $streetName New street name
+     * @param string $buildingNumber New building number
+     * @param CustomerAddressEntity $addressEntity The address entity to check against
+     *
+     * @return bool True if any custom values have changed
+     */
+    private function areCustomFieldsChanged(
+        string $streetName,
+        string $buildingNumber,
+        CustomerAddressEntity $addressEntity
+    ): bool {
+        $currentCustomFields = $addressEntity->getCustomFields() ?? [];
+        $acrisStreet = $currentCustomFields[AcrisCustomField::STREET] ?? null;
+        $acrisHouseNo = $currentCustomFields[AcrisCustomField::HOUSE_NUMBER] ?? null;
+
+        return $acrisStreet !== $streetName || $acrisHouseNo !== $buildingNumber;
     }
 }

--- a/src/Model/CustomerAddressField.php
+++ b/src/Model/CustomerAddressField.php
@@ -21,6 +21,7 @@ final class CustomerAddressField
     public const COUNTRY_ID = 'countryId';
     public const COUNTRY_STATE_ID = 'countryStateId';
     public const EXTENSIONS = 'extensions';
+    public const CUSTOM_FIELDS = 'customFields';
 
     private function __construct()
     {

--- a/src/Model/CustomerAddressUpdatePayload.php
+++ b/src/Model/CustomerAddressUpdatePayload.php
@@ -113,6 +113,17 @@ class CustomerAddressUpdatePayload
     }
 
     /**
+     * Set custom fields data
+     *
+     * @param array<string, mixed> $customFields
+     */
+    public function setCustomFields(array $customFields): self
+    {
+        $this->data[CustomerAddressField::CUSTOM_FIELDS] = $customFields;
+        return $this;
+    }
+
+    /**
      * Set Endereco extension data with type safety
      */
     public function setEnderecoExtension(EnderecoExtensionData $extensionData): self

--- a/src/Resources/config/services/service.php
+++ b/src/Resources/config/services/service.php
@@ -44,7 +44,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // Entity updaters
     $services->set(CustomerAddressEntityUpdater::class);
     $services->set(EnderecoExtensionEntityUpdater::class);
-    
+
     // Array updaters
     $services->set(AddressAsArrayUpdater::class);
     $services->set(AddressExtensionAsArrayUpdater::class);
@@ -81,6 +81,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$arrayUpdater' => service(AddressAsArrayUpdater::class),
             '$extensionArrayUpdater' => service(AddressExtensionAsArrayUpdater::class),
             '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$pluginStatusService' => service(\Endereco\Shopware6Client\Service\PluginStatusService::class),
         ])
         ->public();
 

--- a/src/Resources/config/services/service_customer_address_integrity.php
+++ b/src/Resources/config/services/service_customer_address_integrity.php
@@ -32,6 +32,7 @@ use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddressIntegrityIn
 use Endereco\Shopware6Client\Service\CustomerAddressEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoExtensionEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoService;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Endereco\Shopware6Client\Service\ProcessContextService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -92,7 +93,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 EnderecoCustomerAddressExtensionDefinition::ENTITY_NAME . '.repository'
             ),
             '$entityUpdater' => service(CustomerAddressEntityUpdater::class),
-            '$extensionEntityUpdater' => service(EnderecoExtensionEntityUpdater::class)
+            '$extensionEntityUpdater' => service(EnderecoExtensionEntityUpdater::class),
+            '$pluginStatusService' => service(PluginStatusService::class)
         ]);
     $services->alias(AddressPersistenceStrategyProviderInterface::class, AddressPersistenceStrategyProvider::class);
 

--- a/src/Service/AddressIntegrity/CustomerAddress/AddressPersistenceStrategyProvider.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/AddressPersistenceStrategyProvider.php
@@ -16,6 +16,7 @@ use Endereco\Shopware6Client\Service\AddressCorrection\AddressCorrectionScopeBui
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
 use Endereco\Shopware6Client\Service\CustomerAddressEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoExtensionEntityUpdater;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 
@@ -32,6 +33,7 @@ final class AddressPersistenceStrategyProvider implements AddressPersistenceStra
     private EntityRepository $customerAddressRepository;
     private CustomerAddressEntityUpdater $entityUpdater;
     private EnderecoExtensionEntityUpdater $extensionEntityUpdater;
+    private PluginStatusService $pluginStatusService;
 
     /**
      * @param EntityRepository<CustomerAddressCollection> $customerAddressRepository
@@ -43,7 +45,8 @@ final class AddressPersistenceStrategyProvider implements AddressPersistenceStra
         EntityRepository $customerAddressRepository,
         EntityRepository $customerAddressExtensionRepository,
         CustomerAddressEntityUpdater $entityUpdater,
-        EnderecoExtensionEntityUpdater $extensionEntityUpdater
+        EnderecoExtensionEntityUpdater $extensionEntityUpdater,
+        PluginStatusService $pluginStatusService
     ) {
         $this->additionalAddressFieldChecker = $additionalAddressFieldChecker;
         $this->addressCorrectionScopeBuilder = $addressCorrectionScopeBuilder;
@@ -51,6 +54,7 @@ final class AddressPersistenceStrategyProvider implements AddressPersistenceStra
         $this->customerAddressExtensionRepository = $customerAddressExtensionRepository;
         $this->entityUpdater = $entityUpdater;
         $this->extensionEntityUpdater = $extensionEntityUpdater;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     /**
@@ -83,7 +87,8 @@ final class AddressPersistenceStrategyProvider implements AddressPersistenceStra
                     $this->customerAddressExtensionRepository,
                     $context,
                     $this->entityUpdater,
-                    $this->extensionEntityUpdater
+                    $this->extensionEntityUpdater,
+                    $this->pluginStatusService
                 );
             }
 
@@ -91,7 +96,10 @@ final class AddressPersistenceStrategyProvider implements AddressPersistenceStra
                 return new PersistOnlyExtensionFields(
                     $this->customerAddressExtensionRepository,
                     $context,
-                    $this->extensionEntityUpdater
+                    $this->extensionEntityUpdater,
+                    $this->customerAddressRepository,
+                    $this->entityUpdater,
+                    $this->pluginStatusService
                 );
             }
         }

--- a/src/Service/CustomerAddressEntityUpdater.php
+++ b/src/Service/CustomerAddressEntityUpdater.php
@@ -53,5 +53,11 @@ final class CustomerAddressEntityUpdater
                 $addressEntity->$setterMethod($payloadData[$fieldName]);
             }
         }
+
+        // Update custom fields separately to merge with existing custom fields instead of overwriting
+        if (array_key_exists(CustomerAddressField::CUSTOM_FIELDS, $payloadData)) {
+            $currentFields = $addressEntity->getCustomFields() ?? [];
+            $addressEntity->setCustomFields(array_merge($currentFields, $payloadData[CustomerAddressField::CUSTOM_FIELDS]));
+        }
     }
 }

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -14,6 +14,7 @@ use Endereco\Shopware6Client\Misc\EnderecoConstants;
 use Endereco\Shopware6Client\Model\AddressCheckResult;
 use Endereco\Shopware6Client\Model\CustomerAddressUpdatePayload;
 use Endereco\Shopware6Client\Model\EnderecoExtensionData;
+use Endereco\Shopware6Client\Model\AcrisCustomField;
 use Endereco\Shopware6Client\Service\AddressCheck\CountryCodeFetcherInterface;
 use Endereco\Shopware6Client\Service\AddressCorrection\StreetSplitterInterface;
 use Endereco\Shopware6Client\Service\AddressAsArrayUpdater;
@@ -22,6 +23,7 @@ use Endereco\Shopware6Client\Service\CustomerAddressEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoExtensionEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoService\AgentInfoGeneratorInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\PayloadPreparatorInterface;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerInterface;
@@ -78,6 +80,8 @@ class EnderecoService
 
     protected RequestStack $requestStack;
 
+    private PluginStatusService $pluginStatusService;
+
     /**
      * @param EntityRepository<CountryStateCollection> $countryStateRepository
      * @param EntityRepository<CustomerAddressCollection> $customerAddressRepository
@@ -98,7 +102,8 @@ class EnderecoService
         EnderecoExtensionEntityUpdater $extensionEntityUpdater,
         AddressAsArrayUpdater $arrayUpdater,
         AddressExtensionAsArrayUpdater $extensionArrayUpdater,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        PluginStatusService $pluginStatusService
     ) {
         $this->httpClient = new Client(['timeout' => 3.0, 'connection_timeout' => 2.0]);
         $this->systemConfigService = $systemConfigService;
@@ -116,6 +121,7 @@ class EnderecoService
         $this->arrayUpdater = $arrayUpdater;
         $this->extensionArrayUpdater = $extensionArrayUpdater;
         $this->logger = $logger;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     /**
@@ -277,6 +283,14 @@ class EnderecoService
             $payload->setCity($correction['locality']);
             $payload->setStreet($fullStreet);
 
+            if ($this->pluginStatusService->isAcrisStreetActive()) {
+                $currentCustomFields = $addressEntity->getCustomFields() ?? [];
+                $payload->setCustomFields(array_merge($currentCustomFields, [
+                    AcrisCustomField::STREET => $correction['streetName'],
+                    AcrisCustomField::HOUSE_NUMBER => $correction['buildingNumber']
+                ]));
+            }
+
             $this->entityUpdater->updateFromPayload($payload, $addressEntity);
 
             // If a subdivision code exists in the correction, find the corresponding country state ID and set it
@@ -330,6 +344,14 @@ class EnderecoService
             $payload->setZipcode($correction['postalCode']);
             $payload->setCity($correction['locality']);
             $payload->setStreet($fullStreet);
+
+            if ($this->pluginStatusService->isAcrisStreetActive()) {
+                $currentCustomFields = $addressEntity->getCustomFields() ?? [];
+                $payload->setCustomFields(array_merge($currentCustomFields, [
+                    AcrisCustomField::STREET => $correction['streetName'],
+                    AcrisCustomField::HOUSE_NUMBER => $correction['buildingNumber']
+                ]));
+            }
 
             $this->entityUpdater->updateFromPayload($payload, $addressEntity);
 


### PR DESCRIPTION
When the ACRIS Separate Street plugin is active, any server-side address corrections made by endereco (such as splitting streets via `StreetIsSplitInsurance` or autocorrecting addresses via `AmsStatusIsSetInsurance`) need to be synchronized with ACRIS's custom fields. Previously, endereco only updated the native Shopware fields and its own extension data, leaving the ACRIS custom fields out of sync. To maintain data integrity, these updates must be mirrored into the ACRIS custom fields within the exact same DAL write operation.

Solution:
Extended the internal update payload architecture to support custom fields and injected the ACRIS-specific address properties into the standard endereco address update sequences.

Changes by file:
- CustomerAddressUpdatePayload.php, CustomerAddressEntityUpdater.php, CustomerAddressField.php: Added support for customFields in the payload. Implemented a safe array merge to gracefully merge the new ACRIS properties with existing custom fields, ensuring no third-party plugin data is accidentally overwritten.
- PersistNativeAndExtensionFields.php: Modified the persistence strategy. It now evaluates PluginStatusService->isAcrisStreetActive() and checks if the newly split street name or building number differ from the existing ones. Only if there are actual modifications, the new values are safely  injected into the custom fields  acris_separate_street_address_street and acris_separate_street_address_house_number without overwriting any other custom fields written by third-party plugins.
- EnderecoService.php: Updated applyAddressCheckResult: Before pushing the updated payload, it checks if the ACRIS plugin is active. If true, the corrected street name and building number are safely merged into the address entity's custom fields, keeping the correction perfectly in sync with ACRIS (both for autocorrected and already fully correct addresses).
- service.php, service_customer_address_integrity.php, AddressPersistenceStrategyProvider: Made PluginStatusService available via dependency injection.

The acceptance criteria and other tests were made in sw6-dev-env.
[endereco-acris.log](https://github.com/user-attachments/files/27631668/endereco-acris.log)

Calls of StreetIsSplitInsurance and AmsStatusIsSetInsurance that didn't lead to a writing operation were
manually removed from the log file. During this process, it could be confirmed, that no unnecessary writes were made.
