### PR TITLE
Enforce split street payload format when ACRIS plugin is active

### DIFF
--- a/src/Resources/config/services/service_address_check.php
+++ b/src/Resources/config/services/service_address_check.php
@@ -25,6 +25,7 @@ use Endereco\Shopware6Client\Service\EnderecoService\PayloadPreparatorInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\RequestHeadersGeneratorInterface;
 use Endereco\Shopware6Client\Service\AddressCorrection\StreetSplitterInterface;
 use Endereco\Shopware6Client\Service\EnderecoService;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -67,6 +68,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$customerAddressExtensionRepository' => service('endereco_customer_address_ext_gh.repository'),
             '$orderAddressExtensionRepository' => service('endereco_order_address_ext_gh.repository'),
             '$enderecoService' => service(EnderecoService::class),
+            '$pluginStatusService' => service(PluginStatusService::class),
         ]);
     $services->alias(AddressCheckPayloadBuilderInterface::class, AddressCheckPayloadBuilder::class);
 

--- a/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
+++ b/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
@@ -15,6 +15,7 @@ use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\End
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionCollection;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
 use Endereco\Shopware6Client\Model\AddressCheckData;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Framework\Context;
@@ -86,7 +87,9 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
      * Service for getting sales channel ID from context
      */
     private EnderecoService $enderecoService;
-    
+
+    private PluginStatusService $pluginStatusService;
+
     /**
      * Creates a new AddressCheckPayloadBuilder with required dependencies.
      *
@@ -108,7 +111,8 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
         StreetSplitterInterface $streetSplitter,
         EntityRepository $customerAddressExtensionRepository,
         EntityRepository $orderAddressExtensionRepository,
-        EnderecoService $enderecoService
+        EnderecoService $enderecoService,
+        PluginStatusService $pluginStatusService
     ) {
         $this->countryCodeFetcher = $countryCodeFetcher;
         $this->subdivisionCodeFetcher = $subdivisionCodeFetcher;
@@ -119,6 +123,7 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
         $this->customerAddressExtensionRepository = $customerAddressExtensionRepository;
         $this->orderAddressExtensionRepository = $orderAddressExtensionRepository;
         $this->enderecoService = $enderecoService;
+        $this->pluginStatusService = $pluginStatusService;
     }
 
     /**
@@ -221,6 +226,10 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
      */
     private function shouldUseSplitFormat(Context $context): bool
     {
+        if ($this->pluginStatusService->isAcrisStreetActive()) {
+            return true;
+        }
+
         // Get the sales channel ID from context (if available)
         $salesChannelId = null;
         $source = $context->getSource();

--- a/tests/Unit/Service/AddressCheck/AddressCheckPayloadBuilderTest.php
+++ b/tests/Unit/Service/AddressCheck/AddressCheckPayloadBuilderTest.php
@@ -14,6 +14,7 @@ use Endereco\Shopware6Client\Service\AddressCheck\SubdivisionCodeFetcherInterfac
 use Endereco\Shopware6Client\Service\AddressCorrection\StreetSplitterInterface;
 use Endereco\Shopware6Client\DTO\SplitStreetResultDto;
 use Endereco\Shopware6Client\Service\EnderecoService;
+use Endereco\Shopware6Client\Service\PluginStatusService;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
@@ -31,6 +32,7 @@ class AddressCheckPayloadBuilderTest extends TestCase
     private EntityRepository $customerAddressExtensionRepository;
     private EntityRepository $orderAddressExtensionRepository;
     private EnderecoService $enderecoService;
+    private PluginStatusService $pluginStatusService;
     private Context $context;
 
     protected function setUp(): void
@@ -62,6 +64,7 @@ class AddressCheckPayloadBuilderTest extends TestCase
         $this->customerAddressExtensionRepository = $this->createMock(EntityRepository::class);
         $this->orderAddressExtensionRepository = $this->createMock(EntityRepository::class);
         $this->enderecoService = $this->createMock(EnderecoService::class);
+        $this->pluginStatusService = $this->createMock(PluginStatusService::class);
 
         // Configure common defaults that can be overridden
         if (isset($config['splitStreetEnabled'])) {
@@ -97,7 +100,8 @@ class AddressCheckPayloadBuilderTest extends TestCase
             $this->streetSplitter,
             $this->customerAddressExtensionRepository,
             $this->orderAddressExtensionRepository,
-            $this->enderecoService
+            $this->enderecoService,
+            $this->pluginStatusService
         );
     }
 


### PR DESCRIPTION
The Endereco plugin features a "split street" configuration. When active, it splits the street and house number fields in the form and structures both client-side and server-side Address Check payloads into separate street and houseNumber fields. When inactive, a single streetFull field is used across all payloads instead. When the "ACRIS Separate Street" plugin is installed and active,  this split behavior should be permanently enabled, regardless of the Endereco configuration. However, during server-side operations (like existing customer validation), the payload builder currently only checks the Endereco configuration. If that setting is inactive, it incorrectly builds a combined payload (streetFull), causing a semantic mismatch between the form structure and the payload sent to the API.

Solution:
Updated the payload builder decision logic to always use the split format if the ACRIS plugin is active.

Changes by file:
- src/Service/AddressCheck/AddressCheckPayloadBuilder.php: Injected the PluginStatusService and updated shouldUseSplitFormat() to return true when isAcrisStreetActive() is true.
- src/Resources/config/services/service_address_check.php: Added the PluginStatusService dependency to the AddressCheckPayloadBuilder DI configuration.
- tests/Unit/Service/AddressCheck/AddressCheckPayloadBuilderTest.php: Updated the test setup to mock and inject the new PluginStatusService dependency.

Ref: DEV-555

Verified in sw6-dev-env. Confirmed that payloads are always sent in the split format when ACRIS is active (verified via Network tab and AMS_payload in the Endereco extension table). Without ACRIS, the standard Endereco behavior remains unchanged: payloads use the split format only when the "split street" toggle is enabled; otherwise, they are sent in the combined format.