### PR TITLE
Apply country-specific street formatting when ACRIS plugin is active

### DIFF
--- a/src/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Subscriber/CustomerAddressSubscriber.php
@@ -401,15 +401,13 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
 
         $enderecoStreet = (string)$input->get('enderecoStreet', '');
         $enderecoHouseNumber = (string)$input->get('enderecoHousenumber', '');
-        $skipSyncStreet = false;
 
         if ($this->pluginStatusService->isAcrisStreetActive()) {
             $acrisHouseNumber = (string)$input->get('houseNumber', '');
             if ($acrisHouseNumber !== '') {
                 $enderecoStreet = (string)$input->get('street', '');
                 $enderecoHouseNumber = $acrisHouseNumber;
-                // ACRIS already successfully divided the address, skip endereco splitting.
-                $skipSyncStreet = true;
+                $output['street'] = ''; // will be rebuild by syncStreet
             }
         }
 
@@ -424,9 +422,7 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
         ];
 
         // Make sure the default street and endereco street name and house number are synchronized.
-        if (!$skipSyncStreet) {
-            $this->enderecoService->syncStreet($output, $context, $salesChannelId);
-        }
+        $this->enderecoService->syncStreet($output, $context, $salesChannelId);
 
         // Calculate payload. Pass the pre-split fields so the builder can skip its own
         // street splitter (see AddressCheckPayloadBuilder::extractSplitAddressFromArray).


### PR DESCRIPTION
Problem:
When the ACRIS plugin is active and provides a split street, the full street was saved with default formatting (e.g., German format), ignoring country-specific variations where the house number comes first (like in France, UK, and USA). Because there was a gate preventing the execution of EnderecoService::syncStreet() when ACRIS was active, our correct country-specific formatting was never applied.

Solution:
- Removed the skipSyncStreet gate in CustomerAddressSubscriber to ensure syncStreet() is always executed.
- Explicitly cleared the full street string  in the data mapping event if ACRIS provides valid split street data.
- This forces syncStreet() to execute the logic block that correctly rebuilds a full street string out of split inputs, applying endereco's country-aware formatting.

Ref: DEV-560, DEV-490

Performed static QA (PHPCS/PHPStan) and tested changes in sw6-dev-env with German and French addresses. German address behavior remains unchanged. For French addresses, the full street is now correctly formatted in the customer_address table, and the split values in the Acris Custom Fields and endereco extension table are correct.