### PR TITLE
Latch isPayPalAddress flag to true-only

### DIFF
--- a/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
@@ -56,6 +56,10 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
             throw new \RuntimeException('The address extension should be set at this point');
         }
 
+        if ($addressExtension->isPayPalAddress()) {
+            return; //PayPal flag latched, never reset to false
+        }
+
         $customer = $this->getCustomer($addressEntity->getCustomerId(), $context);
         $flagValue = $this->checkIfFromPayPal($customer);
         if ($addressExtension->isPayPalAddress() !== $flagValue) {


### PR DESCRIPTION
Currently PayPalExpressFlagIsSetInsurance::ensure() unconditionally overwrites the isPayPalAddress flag with whatever checkIfFromPayPal() returns at that moment — in both directions. This is currently harmless because the existing detection source (payPalExpressPayerId in customer.custom fields) is permanent once set.

However, the upcoming integration of CrefoPay introduces session-based markers as a new detection source. Since session data is volatile, the flag would flip back to false as soon as the session marker disappears, incorrectly treating a previously identified remote address as a regular customer address in downstream logic.

This commit adds an early return when the flag is already true, ensuring that once an address is flagged, it remains latched to true.

Ref: DEV-568

The changes were tested in sw6-dev-env confirming the desired behaviour.