### PR TITLE
Fix typo in sw_extends path

### DIFF
--- a/src/Resources/views/storefront/component/address/hidden-address-form.html.twig
+++ b/src/Resources/views/storefront/component/address/hidden-address-form.html.twig
@@ -1,4 +1,4 @@
-{% sw_extends '@EnderecoShoppware6Client/storefront/component/address/address-form.html.twig' %}
+{% sw_extends '@EnderecoShopware6Client/storefront/component/address/address-form.html.twig' %}
 
 {% block component_address_form_country %}
     <input type="hidden" id="{{ prefix }}AddressCountry"


### PR DESCRIPTION
The path for the sw_extends-function had a typo.
This did not result in any errors so far,
because of the way sw_extends works.

As long as the rest of the file path is correct,
Shopware can fallback to its own template file under  @Storefront.

However trying to access a block of the parent file, that's not also present in the native Shopware template file, would result in a Storefront Exception.

Fixing the typo in the sw_extends path,
ensures that any blocks inside the parent file,
are correctly inherited.

Ref: DEV-586