### PR TITLE
Extract additional address line into the street field

### DIFF
--- a/src/Resources/config/services/service_customer_address_integrity.php
+++ b/src/Resources/config/services/service_customer_address_integrity.php
@@ -29,6 +29,7 @@ use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\IntegrityI
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\StreetIsSplitInsurance;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddressIntegrityInsurance;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddressIntegrityInsuranceInterface;
+use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\AdditionalAddressFieldInStreetInsurance;
 use Endereco\Shopware6Client\Service\CustomerAddressEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoExtensionEntityUpdater;
 use Endereco\Shopware6Client\Service\EnderecoService;
@@ -53,6 +54,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services
         ->instanceof(IntegrityInsurance::class)
         ->tag('endereco.shopware6_client.customer_address_integrity_insurance');
+
+    /**
+     * Ensures that additionalAddressLine1 is merged into the street field and then cleared.
+     * This normalizes PayPal addresses where street number data was stored in the wrong field.
+     */
+    $services->set(AdditionalAddressFieldInStreetInsurance::class)
+    -> args([
+            '$processContext' => service(ProcessContextService::class),
+            '$additionalAddressFieldChecker' => service(AdditionalAddressFieldCheckerInterface::class),
+            '$customerAddressRepository' => service('customer_address.repository'),
+        ]);
 
     /**
      * Ensures the address extension entity exists both in the entity and the database.

--- a/src/Service/AddressIntegrity/CustomerAddress/AdditionalAddressFieldInStreetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/AdditionalAddressFieldInStreetInsurance.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress;
+
+use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
+use Endereco\Shopware6Client\Model\CustomerAddressUpdatePayload;
+use Endereco\Shopware6Client\Service\AddressCheck\AdditionalAddressFieldCheckerInterface;
+use Endereco\Shopware6Client\Service\ProcessContextService;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+
+/* Ensures that street numbers that are wrongfully stored in additionalAddressLine1
+ * are moved into the street and additionalAddressLine1 is emptied.
+*/
+final class AdditionalAddressFieldInStreetInsurance implements IntegrityInsurance
+{
+    private ProcessContextService $processContext;
+
+    private AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker;
+
+    private EntityRepository $customerAddressRepository;
+
+    public function __construct(
+        ProcessContextService $processContext,
+        AdditionalAddressFieldCheckerInterface $additionalAddressFieldChecker,
+        EntityRepository $customerAddressRepository,
+    ) {
+        $this->processContext = $processContext;
+        $this->additionalAddressFieldChecker = $additionalAddressFieldChecker;
+        $this->customerAddressRepository = $customerAddressRepository;
+    }
+
+    /**
+     * Get the priority for this insurance
+     * This has to run after PayPalExpressFlagIsSetInsurance
+     * @return int Priority value
+     */
+    public static function getPriority(): int
+    {
+        return -8;
+    }
+
+    /**
+     * Ensures that a street number, that is wrongfully stored in additionalAddressLine1,
+     * is merged into the street field and additionalAddressLine1 then cleared.
+     * This is needed when a customer address is created by Paypal Express Checkout
+     * and the additional address lines are set to not show in the Shopware configuration.
+     *
+     * @param CustomerAddressEntity $addressEntity The address entity to process
+     * @param Context $context The Shopware context
+     */
+    public function ensure(CustomerAddressEntity $addressEntity, Context $context): void
+    {
+        $addressExtension = $addressEntity->getExtension(CustomerAddressExtension::ENDERECO_EXTENSION);
+        $additionalAddressLine1 = $addressEntity->getAdditionalAddressLine1();
+
+        if (!$addressExtension instanceof EnderecoCustomerAddressExtensionEntity) {
+            throw new \RuntimeException('The address extension should be set at this point');
+        }
+
+        if (
+            empty($additionalAddressLine1) ||
+            !$addressExtension->isPayPalAddress() ||
+            !$this->processContext->isStorefront() ||
+            $this->additionalAddressFieldChecker->hasAdditionalAddressField($context)
+        ) {
+            return;
+        }
+
+        $street = $addressEntity->getStreet();
+        $mergedStreet = $street . ' ' . $additionalAddressLine1;
+
+        $addressEntity->setStreet($mergedStreet);
+        $addressEntity->setAdditionalAddressLine1('');
+
+        $addressId = $addressEntity->getId();
+
+        $payload = new CustomerAddressUpdatePayload($addressId);
+
+        $payload->setStreet($mergedStreet);
+        $payload->setAdditionalAddressLine1('');
+
+        $this->customerAddressRepository->update([$payload->toArray()], $context);
+    }
+}

--- a/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
@@ -38,7 +38,7 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
      */
     public static function getPriority(): int
     {
-        return -10;
+        return -5;
     }
 
     /**


### PR DESCRIPTION
The PayPal Express Checkout maps its additional address field to Shopwares additionalAddressLine1. If a PayPal customer writes his street number into the additional address field, while the display of the additionalAddressLines is disabled in the Shopware configuration, the address check fails due to a missing street number and the customer has to manually edit the address.

This is prevented by appending the value of additionalAddressLine1 to the street before the StreetIsSplitInsurance is applied and after PayPalExpressFlagIsSetInsurance is applied.

Ref: DEV-605