### PR TITLE
Provide customerId in CustomerAddressUpdatePayload

### DIFF
--- a/src/Controller/Storefront/AddressController.php
+++ b/src/Controller/Storefront/AddressController.php
@@ -155,7 +155,7 @@ class AddressController extends StorefrontController
         $this->eventDispatcher->dispatch($mappingEvent, CustomerEvents::MAPPING_ADDRESS_CREATE);
         $addressData = $mappingEvent->getOutput();
 
-        $payload = (new CustomerAddressUpdatePayload($addressId))
+        $payload = (new CustomerAddressUpdatePayload($addressId, $customer->getId()))
             ->setStreet($addressData['street'] ?? '')
             ->setZipcode($addressData['zipcode'] ?? '')
             ->setCity($addressData['city'] ?? '')

--- a/src/Model/AddressPersistenceStrategy/PersistNativeAndExtensionFields.php
+++ b/src/Model/AddressPersistenceStrategy/PersistNativeAndExtensionFields.php
@@ -70,7 +70,7 @@ final class PersistNativeAndExtensionFields implements CustomerAddressPersistenc
             throw new \RuntimeException('Address entity cannot be null');
         }
 
-        $payload = new CustomerAddressUpdatePayload($addressEntity->getId());
+        $payload = new CustomerAddressUpdatePayload($addressEntity->getId(), $addressEntity->getCustomerId());
         $isNativeChanged = $this->maybeUpdateNative(
             $normalizedStreetFull,
             $normalizedAdditionalInfo,

--- a/src/Model/AddressPersistenceStrategy/PersistOnlyExtensionFields.php
+++ b/src/Model/AddressPersistenceStrategy/PersistOnlyExtensionFields.php
@@ -176,7 +176,7 @@ final class PersistOnlyExtensionFields implements CustomerAddressPersistenceStra
             AcrisCustomField::HOUSE_NUMBER => $buildingNumber,
         ]);
 
-        $payload = new CustomerAddressUpdatePayload($addressEntity->getId());
+        $payload = new CustomerAddressUpdatePayload($addressEntity->getId(), $addressEntity->getCustomerId());
         $payload->setCustomFields($newCustomFields);
 
         $this->addressRepository->update([$payload->toArray()], $this->context);

--- a/src/Model/CustomerAddressField.php
+++ b/src/Model/CustomerAddressField.php
@@ -22,6 +22,7 @@ final class CustomerAddressField
     public const COUNTRY_STATE_ID = 'countryStateId';
     public const EXTENSIONS = 'extensions';
     public const CUSTOM_FIELDS = 'customFields';
+    public const CUSTOMER_ID = 'customerId';
 
     private function __construct()
     {

--- a/src/Model/CustomerAddressUpdatePayload.php
+++ b/src/Model/CustomerAddressUpdatePayload.php
@@ -36,9 +36,13 @@ class CustomerAddressUpdatePayload
 
     private ?EnderecoExtensionData $enderecoExtensionData = null;
 
-    public function __construct(string $addressId)
+    public function __construct(string $addressId, ?string $customerId = null)
     {
         $this->data[CustomerAddressField::ID] = $addressId;
+
+        if ($customerId !== null) {
+            $this->data[CustomerAddressField::CUSTOMER_ID] = $customerId;
+        }
     }
 
     /**

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -179,7 +179,7 @@ class EnderecoService
         $addressExtension = EnderecoCustomerAddressExtensionEntity::createWithDefaultValues($addressEntity);
         $addressEntity->addExtension(CustomerAddressExtension::ENDERECO_EXTENSION, $addressExtension);
 
-        $payload = new CustomerAddressUpdatePayload($addressEntity->getId());
+        $payload = new CustomerAddressUpdatePayload($addressEntity->getId(), $addressEntity->getCustomerId());
         $extensionData = new EnderecoExtensionData();
         $extensionData->setAmsRequestPayload($addressExtension->getAmsRequestPayload())
             ->setAmsStatus($addressExtension->getAmsStatus())
@@ -260,8 +260,9 @@ class EnderecoService
         Context $context
     ): void {
         $addressId = $addressEntity->getId();
+        $customerId = $addressEntity->getCustomerId();
 
-        $payload = new CustomerAddressUpdatePayload($addressId);
+        $payload = new CustomerAddressUpdatePayload($addressId, $customerId);
 
         if ($addressCheckResult->isAutomaticCorrection() && $this->isAutocorrectionAllowedInSettings($context)) {
             // In case of automatic correction, apply the first prediction to the customer address and generate


### PR DESCRIPTION
The data array inside the CustomerAddressUpdatePayload class does not have a customerId-key.
While this key is not neccessary to update an address, the B2B Suite plugin from Shopware, expects it to be set in the payload.

A missing customerId-key results in an ErrorException in the storefront, when  the B2B Suite plugin is active and the .env-variable  APP_DEBUG=1 is set.

By providing the customerId as an optional parameter to CustomerAddressUpdatePayload, this error can be prevented, while keeping backwards compatibelity in case customerId is missing.

Ref: DEV-582