### PR TITLE
Abort CrefoPay PayPal Express session when address correction modal is required

### DIFF
--- a/src/Compatibility/CrefoPay/CrefoPaySessionKeys.php
+++ b/src/Compatibility/CrefoPay/CrefoPaySessionKeys.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Compatibility\CrefoPay;
+
+final class CrefoPaySessionKeys
+{
+    public const PAYPAL_EXPRESS_TRANSACTION = 'crefopay-paypal-express-transaction';
+    public const PAYPAL_EXPRESS_ACTIVE = 'paypalExpressActive';
+}

--- a/src/Resources/config/services/service_customer_address_integrity.php
+++ b/src/Resources/config/services/service_customer_address_integrity.php
@@ -23,6 +23,7 @@ use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\AddressPer
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\AddressPersistenceStrategyProviderInterface;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\AmsRequestPayloadIsUpToDateInsurance;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\AmsStatusIsSetInsurance;
+use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\CrefoPayExpressAbortedOnCorrectionInsurance;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\FlagIsSetInsurance\AmazonFlagIsSetInsurance;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\FlagIsSetInsurance\PayPalExpressFlagIsSetInsurance;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\IntegrityInsurance;
@@ -144,6 +145,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$addressExtensionRepository' => service(
                 EnderecoCustomerAddressExtensionDefinition::ENTITY_NAME . '.repository'
             ),
+        ]);
+
+    /**
+     * Aborts an active CrefoPay PayPal Express checkout when the address requires modal correction,
+     * preventing the express session from blocking the correction flow.
+     */
+    $services->set(CrefoPayExpressAbortedOnCorrectionInsurance::class)
+        ->args([
+            '$processContext' => service(ProcessContextService::class),
+            '$requestStack'   => service('request_stack'),
         ]);
 
     /**

--- a/src/Service/AddressIntegrity/CustomerAddress/CrefoPayExpressAbortedOnCorrectionInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/CrefoPayExpressAbortedOnCorrectionInsurance.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress;
+
+use Endereco\Shopware6Client\Compatibility\CrefoPay\CrefoPaySessionKeys;
+use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
+use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
+use Endereco\Shopware6Client\Service\ProcessContextService;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * When a modal-level AMS correction is required, removes the CrefoPay PayPal Express
+ * session markers so the user can go through the standard correction flow instead of
+ * being held in PayPal Express mode.
+ */
+final class CrefoPayExpressAbortedOnCorrectionInsurance implements IntegrityInsurance
+{
+    public function __construct(
+        private readonly ProcessContextService $processContext,
+        private readonly RequestStack $requestStack
+    ) {
+    }
+
+    public static function getPriority(): int
+    {
+        return -30;
+    }
+
+    public function ensure(CustomerAddressEntity $addressEntity, Context $context): void
+    {
+        $addressExtension = $addressEntity->getExtension(CustomerAddressExtension::ENDERECO_EXTENSION);
+
+        if (!$addressExtension instanceof EnderecoCustomerAddressExtensionEntity) {
+            throw new \RuntimeException('The address extension should be set at this point');
+        }
+
+        if (!$this->processContext->isStorefront()) {
+            return;
+        }
+
+        $request = $this->requestStack->getMainRequest();
+        if ($request === null) {
+            return;
+        }
+
+        $session = $request->getSession();
+        if (!$session->has(CrefoPaySessionKeys::PAYPAL_EXPRESS_TRANSACTION)) {
+            return;
+        }
+
+        if (!$addressExtension->needsCorrectionInFrontend()) {
+            return;
+        }
+
+        // When native-field overwriting is disabled, minor corrections are applied without a
+        // modal by the frontend JS instead of server-side. The PayPal Express session must stay intact.
+        if ($addressExtension->hasMinorCorrection()) {
+            return;
+        }
+
+        $session->remove(CrefoPaySessionKeys::PAYPAL_EXPRESS_TRANSACTION);
+        unset($_SESSION[CrefoPaySessionKeys::PAYPAL_EXPRESS_ACTIVE]);
+    }
+}


### PR DESCRIPTION
In the CrefoPay PayPal Express flow, CrefoPay intentionally freezes the shipping address: it removes the address-edit button on the confirm page and keeps the payment transaction bound to the PayPal-supplied address.

When Endereco determines that a correction modal must be shown for such an address, the checkout is broken in two ways:
- The "Edit" link inside the modal targets the removed Shopware edit button and leads nowhere.
- If the customer accepts a suggestion, the updated address diverges from the frozen payment authorisation (shipped to the new address, authorised against the old one).

Solution: introduce CrefoPayExpressAbortedOnCorrectionInsurance, that runs after AmsStatusIsSetInsurance has determined the AMS status. When a storefront request carries an active CrefoPay PayPal Express session and the address extension reports that a correction modal is required, the insurance removes both CrefoPay session markers. This converts the session to a normal CrefoPay PayPal checkout and forces a fresh payment authorisation. This is unavoidable whenever the address changes.

Minor corrections and formatting variants are intentionally allowed through for two reasons: they do not trigger the modal and therefore do not break the workflow, and they do not constitute a real address change, so no meaningful deviation arises between the PayPal-supplied address and the final one.

Ref: DEV-604