### PR TITLE
Optimize static qa scripts

### DIFF
--- a/check_imports.php
+++ b/check_imports.php
@@ -2,6 +2,13 @@
 
 require_once 'vendor/autoload.php';
 
+// Classes from optional third-party plugins that may not be installed in every environment.
+// These are loaded conditionally at runtime and are safe to skip here.
+$optionalNamespacePrefixes = [
+    'CrefoPay\\',
+
+    ];
+
 function findAllPhpFiles($dir, &$allFiles = []) {
     $files = scandir($dir);
 
@@ -45,6 +52,16 @@ foreach ($phpFiles as $file) {
 }
 
 $allClasses = array_unique($allClasses);
+$allClasses = array_filter($allClasses, function ($class) use ($optionalNamespacePrefixes) {
+    foreach ($optionalNamespacePrefixes as $prefix) {
+        if (str_starts_with($class, $prefix)) {
+            return false;
+        }
+    }
+    return true;
+});
+
+
 $missingClasses = checkClassExistence($allClasses);
 
 if (!empty($missingClasses)) {

--- a/test_php_versions.sh
+++ b/test_php_versions.sh
@@ -6,34 +6,78 @@ versions=("8.2" "8.3")
 # Find all PHP files in the current directory and subdirectories, excluding vendor, node_modules and shops folders
 php_files=$(find . -type d \( -path './vendor' -o -path './node_modules' -o -path './shops' \) -prune -o -type f -name '*.php' -print)
 
-# Initialize a flag to track syntax errors
-syntax_error_found=0
+# Run syntax check for a single PHP version inside one container (all files at once).
+# Progress and status go to stderr (terminal). Error lines go to stdout (captured by parent via FD).
+run_version() {
+    local version=$1
+    echo "Testing with PHP $version..." >&2
 
-# Loop through each version and run tests for each PHP file
-for version in "${versions[@]}"
-do
-    if [ $syntax_error_found -eq 1 ]; then
-        break # Exit the version loop if an error is found
+    local container_output
+    if container_output=$(echo "$php_files" | docker run --rm -i \
+        -v "$(pwd)":/app -w /app "php:$version-cli" \
+        sh -c '
+            NL="
+"
+            version=$1
+            errors=0
+            while IFS= read -r f; do
+                printf "Testing %s with PHP %s...\n" "$f" "$version" >&2
+                out=$(php -l "$f" 2>&1)
+                if [ $? -ne 0 ]; then
+                    first_line=$(printf "%s" "$out" | grep -v "^$" | head -1)
+                    printf "%s\t%s\n" "$f" "$first_line"
+                    errors=1
+                fi
+            done
+            exit $errors
+        ' _ "$version"); then
+        echo "PHP $version: OK" >&2
+    else
+        while IFS=$'\t' read -r file output; do
+            printf "%s\t%s\t%s\n" "$version" "$file" "$output"
+        done <<< "$container_output"
+        exit 1
     fi
-    echo "Testing with PHP $version..."
-    for file in $php_files
-    do
-        if [ $syntax_error_found -eq 1 ]; then
-            break # Exit the file loop if an error is found
-        fi
-        echo "Testing the syntax of $file"
-        # Run PHP syntax check and capture the output
-        output=$(docker run --rm -v "$(pwd)":/app -w /app php:$version-cli php -l $file)
-        if [[ $output == *"Errors parsing"* ]]; then
-            echo "Syntax error found in $file with PHP $version: $output"
-            syntax_error_found=1
-        fi
-    done
+}
+
+# Run all versions in parallel; each gets its own FD to capture stdout (error lines only)
+pids=()
+pids_versions=()
+fds=()
+
+for version in "${versions[@]}"; do
+    exec {fd}< <(run_version "$version")
+    pids+=($!)
+    pids_versions+=("$version")
+    fds+=("$fd")
 done
 
-# Check if any syntax errors were found during the tests
-if [ $syntax_error_found -eq 1 ]; then
-    echo "Syntax errors were found."
+# Wait for all parallel jobs and read error lines from each version's pipe buffer
+failed_versions=()
+all_errors=()
+
+for i in "${!pids[@]}"; do
+    wait "${pids[$i]}"
+    exit_code=$?
+    fd="${fds[$i]}"
+
+    if [ $exit_code -ne 0 ]; then
+        failed_versions+=("${pids_versions[$i]}")
+        while IFS= read -r line; do
+            all_errors+=("$line")
+        done <&"$fd"
+    fi
+
+    exec {fd}<&-
+done
+
+if [ ${#failed_versions[@]} -gt 0 ]; then
+    echo ""
+    echo "Syntax errors found:"
+    for error_line in "${all_errors[@]}"; do
+        IFS=$'\t' read -r version file output <<< "$error_line"
+        printf "Syntax error found in %s with PHP %s:\n%s\n" "$file" "$version" "$output"
+    done
     exit 1
 else
     echo "No syntax errors found."


### PR DESCRIPTION
The qa scripts called via composer qa must be run
and passed successfully before submitting any
pull request. Currently the performance of the
PHP version check is making up the bulk of the
run time, because for each tested file, a new
docker container is being used.

Furthermore the check_imports script fails,
if a file in the src directory uses a class outside of it. This causes the static qa to fail, if a class of a third party plugin is decorated or extended.

By running a docker container for each PHP version, instead of each file and letting them run in parallel, the run time of the PHP version check is
decreased massively.

By supplying an optional NamespacePrefixes array
inside the check_imports script, classes of
third party plugins can be exempt from this check.