### PR TITLE
Detect CrefoPay PayPal Express transactions in PayPalExpressFlagIsSet…

### DIFF
--- a/src/Resources/config/services/service_customer_address_integrity.php
+++ b/src/Resources/config/services/service_customer_address_integrity.php
@@ -156,6 +156,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$addressExtensionRepository' => service(
                 EnderecoCustomerAddressExtensionDefinition::ENTITY_NAME . '.repository'
             ),
+            '$requestStack' => service('request_stack'),
         ]);
 
     /**

--- a/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Insurance class to handle PayPal Express address flag setting
@@ -23,6 +24,7 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
 
     /** @var EntityRepository<EnderecoCustomerAddressExtensionCollection>  */
     private EntityRepository $addressExtensionRepository;
+    private RequestStack $requestStack;
 
     /**
      * @param EntityRepository<CustomerCollection> $customerRepository Repository to fetch customer data
@@ -30,10 +32,12 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
      */
     public function __construct(
         EntityRepository $customerRepository,
-        EntityRepository $addressExtensionRepository
+        EntityRepository $addressExtensionRepository,
+        RequestStack $requestStack
     ) {
         $this->customerRepository = $customerRepository;
         $this->addressExtensionRepository = $addressExtensionRepository;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -96,7 +100,16 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
     {
         /** @var array<string, mixed>|null $customerCustomFields */
         $customerCustomFields = $customer->getCustomFields();
-        return isset($customerCustomFields['payPalExpressPayerId']);
+        if (isset($customerCustomFields['payPalExpressPayerId'])) {
+            return true;
+        }
+
+        if ($this->requestStack->getMainRequest() === null) {
+            return false; //CrefoPay-Session check not possible without Main Request
+        }
+
+        $session = $this->requestStack->getMainRequest()->getSession();
+        return $session->has('crefopay-paypal-express-transaction');
     }
 
     /**


### PR DESCRIPTION
…Insurance

The existing checkIfFromPayPal() only checks for `payPalExpressPayerId` in the customer's custom fields — a marker set exclusively by SwagPayPal's Express Checkout. CrefoPay's PayPal Express flow also imports a customer and address from the PayPal profile, but leaves no persistent marker. Its indicators are session-bound, so CrefoPay-imported addresses are not detected, the flag stays false, and the PayPal Express validation branch is never activated for them.

Solution: The CrefoPay-written Symfony session key `crefopay-paypal-express-transaction` is now recognised as a second source for detecting a PayPal Express payment. Because CrefoPay's marker only exists within an active HTTP session, the check is skipped when no main request is present. The SwagPayPal custom field check runs first and is unaffected by the changes— that field is DB-persisted and readable in any execution context.

Ref: DEV-570