### PR TITLE
Decorate CrefoPay CartEventListener

### DIFF
--- a/src/Compatibility/CrefoPay/CartEventListenerDecorator.php
+++ b/src/Compatibility/CrefoPay/CartEventListenerDecorator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Compatibility\CrefoPay;
+
+use CrefoPay\Payment\Storefront\EventListener\Cart\CartEventListener;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Suppresses CrefoPay's CartEventListener on Endereco's own correction routes to
+ * prevent the listener from interfering with address-save requests.
+ *
+ * COUPLING WARNING: This decorator is bound to a concrete CrefoPay class name.
+ * EnderecoShopware6Client::isCrefoPayActive() guards against a missing class (boot crash),
+ * but two silent failure modes remain unguarded:
+ *   - The class is renamed and the old name still exists: decorator wraps the wrong class.
+ *   - The class exists under the same name but behaves differently: decorator has no effect.
+ * In both cases Endereco's correction AJAX will clear the CrefoPay session again.
+ * Re-verify after every CrefoPay version update.
+ */
+final class CartEventListenerDecorator implements EventSubscriberInterface
+{
+    private const ENDERECO_CORRECTION_ROUTES = [
+        'frontend.endereco.account.address.edit.save',
+        'frontend.endereco.service_proxy'
+    ];
+
+    public function __construct(
+        // @phpstan-ignore-next-line
+        private readonly CartEventListener $inner,
+        private readonly RequestStack $requestStack
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        // @phpstan-ignore-next-line
+        return CartEventListener::getSubscribedEvents();
+    }
+
+    /**
+     * Catches every event-handler call that the dispatcher dispatches to this subscriber.
+     * Skips the inner subscriber when the current request is an Endereco correction route.
+     *
+     * @param mixed[] $arguments
+     */
+    public function __call(string $name, array $arguments): mixed
+    {
+        if ($this->isEnderecoRequest()) {
+            return null;
+        }
+
+        return $this->inner->$name(...$arguments);
+    }
+
+    private function isEnderecoRequest(): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request === null) {
+            return false;
+        }
+
+        return \in_array(
+            $request->attributes->get('_route'),
+            self::ENDERECO_CORRECTION_ROUTES,
+            true
+        );
+    }
+}

--- a/src/EnderecoShopware6Client.php
+++ b/src/EnderecoShopware6Client.php
@@ -44,6 +44,36 @@ class EnderecoShopware6Client extends Plugin
         $confDir = \rtrim($this->getPath(), '/') . '/Resources/config';
 
         $configLoader->load($confDir . '/{packages}/*.yaml', 'glob');
+
+        if ($this->isCrefoPayActive($container)) {
+            $configLoader->load($confDir . '/compat_crefopay.php');
+        }
+    }
+
+    private function isCrefoPayActive(ContainerBuilder $container): bool
+    {
+        /** @var array<class-string, array{name: string, path: string, class: class-string}> $activePlugins */
+        $activePlugins = $container->getParameter('kernel.active_plugins');
+        $search = 'CrefoPay';
+        $isActive = false;
+        foreach (array_keys($activePlugins) as $key) {
+            if (is_string($key) && str_contains($key, $search)) {
+                $isActive = true;
+                break;
+            }
+        }
+
+        if (!$isActive) {
+            return false;
+        }
+
+        // Guard against CrefoPay renaming the class: if the decoration target no longer
+        // exists, skip loading rather than crashing the container.
+        if (!class_exists(\CrefoPay\Payment\Storefront\EventListener\Cart\CartEventListener::class)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Resources/config/compat_crefopay.php
+++ b/src/Resources/config/compat_crefopay.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use CrefoPay\Payment\Storefront\EventListener\Cart\CartEventListener;
+use Endereco\Shopware6Client\Compatibility\CrefoPay\CartEventListenerDecorator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    /**
+     * COUPLING WARNING: ->decorate() targets a concrete CrefoPay class name.
+     * EnderecoShopware6Client::isCrefoPayActive() guards against a missing class (boot crash),
+     * but silent failures remain: a renamed class with the old name still present, or a same-named
+     * class that behaves differently, will both cause Endereco's correction AJAX to clear the
+     * CrefoPay session again. Re-verify after every CrefoPay version update.
+     */
+    $services->set(CartEventListenerDecorator::class)
+        // @phpstan-ignore-next-line
+        ->decorate(CartEventListener::class)
+        ->args([
+            service(CartEventListenerDecorator::class . '.inner'),
+            service('request_stack'),
+        ])
+        ->tag('kernel.event_subscriber');
+};


### PR DESCRIPTION
CrefoPay's CartEventListener (kernel.event_subscriber) fires on every storefront request and removes the PayPal Express session markers (crefopay-paypal-express-transaction, paypalExpressActive) for any path outside a narrow allowlist (e.g. /checkout/, /widgets/,/crefo-pay/). Endereco's correction routes POST /account/endereco/address and POST /endereco/service-proxy fall outside that allowlist.

As a result, when CrefoPay's PayPal Express flow is active, the two Endereco routes cause CrefoPay's CartEventListener to clear the Express session markers: the address-check proxy route at /endereco/service-proxy, which Endereco's JS calls to validate the PayPal-supplied address, and the correction-save route at /account/endereco/address, which persists an accepted address suggestion. Either request clears the markers, causing the subsequent order completion to fail because the
crefopay-paypal-express-transactionstruct — read by CrefoPay's confirm, edit-order and order-finish paths — is gone.

Solution: A Symfony decorator (CartEventListenerDecorator) wraps CrefoPay's listener and short-circuits it when the current request targets one of Endereco's own correction routes.
The decorator is loaded conditionally in EnderecoShopware6Client::build() to prevent a Symfony boot failure in installations without CrefoPay. Because an installed-but-inactive plugin still ships the class to the autoloader, two checks are required: first whether the CrefoPay plugin is active via %kernel.active_plugins%, then whether the decorated class exists on disk. Both the decorator class and the service definition carry a coupling warning for mandatory re-verification after every CrefoPay version update.

Ref: DEV-569