### PR TITLE
Remove redundant isPayPalAddress preset from address mapping

### DIFF
--- a/src/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Subscriber/CustomerAddressSubscriber.php
@@ -417,8 +417,7 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
             'houseNumber' => $enderecoHouseNumber,
             'amsStatus' => $input->get('amsStatus') ?? EnderecoBaseAddressExtensionEntity::AMS_STATUS_NOT_CHECKED,
             'amsTimestamp' => (int) $input->get('amsTimestamp', 0),
-            'amsPredictions' => $predictions,
-            'isPayPalAddress' => false // We will calculate it later.
+            'amsPredictions' => $predictions
         ];
 
         // Make sure the default street and endereco street name and house number are synchronized.


### PR DESCRIPTION
Setting isPayPalAddress to false in CustomerAddressSubscriber was unnecessary because PayPalExpressFlagIsSetInsurance recalculates the flag on every address load anyway. For SwagPayPal addresses this worked fine, as the insurance would restore the flag to true using the payPalExpressPayerId custom field.

For CrefoPay PayPal Express addresses the situation is different: when a modal-level AMS correction is required, CrefoPayExpressAbortedOnCorrectionInsurance clears the CrefoPay session markers before the address is saved. With those markers gone, PayPalExpressFlagIsSetInsurance has no signal left to set the flag back to true, leaving the address permanently unmarked as a PayPal address.

Solution: Remove the preset in CustomerAddressSubscriber so the flag is solely managed by PayPalExpressFlagIsSetInsurance. This also allows the latch in PayPalExpressFlagIsSetInsurance, which prevents the flag from ever being reset from true to false, to take full effect.

Ref: DEV-634

Tested in sw6-dev-env. Detailled description inside the Jira ticket.