### PR TITLE
Replace hardcoded CrefoPay session key with centralized constant

### DIFF
--- a/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/FlagIsSetInsurance/PayPalExpressFlagIsSetInsurance.php
@@ -2,6 +2,7 @@
 
 namespace Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\FlagIsSetInsurance;
 
+use Endereco\Shopware6Client\Compatibility\CrefoPay\CrefoPaySessionKeys;
 use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
 use Endereco\Shopware6Client\Service\AddressIntegrity\CustomerAddress\IntegrityInsurance;
@@ -108,7 +109,7 @@ final class PayPalExpressFlagIsSetInsurance implements IntegrityInsurance
         }
 
         $session = $this->requestStack->getMainRequest()->getSession();
-        return $session->has('crefopay-paypal-express-transaction');
+        return $session->has(CrefoPaySessionKeys::PAYPAL_EXPRESS_TRANSACTION);
     }
 
     /**


### PR DESCRIPTION
PayPalExpressFlagIsSetInsurance referenced the CrefoPay session key as a string literal, making it hard to maintain and prone to errors.

Improvement:
Now uses CrefoPaySessionKeys::PAYPAL_EXPRESS_TRANSACTION instead.

Ref: DEV-633