### PR TITLE
Add B2B suite compatibelity to AdditionalAddressFieldInStreetInsurance

### DIFF
--- a/src/Service/AddressIntegrity/CustomerAddress/AdditionalAddressFieldInStreetInsurance.php
+++ b/src/Service/AddressIntegrity/CustomerAddress/AdditionalAddressFieldInStreetInsurance.php
@@ -109,8 +109,9 @@ final class AdditionalAddressFieldInStreetInsurance implements IntegrityInsuranc
         $addressEntity->setAdditionalAddressLine1('');
 
         $addressId = $addressEntity->getId();
+        $customerId = $addressEntity->getCustomerId();
 
-        $payload = new CustomerAddressUpdatePayload($addressId);
+        $payload = new CustomerAddressUpdatePayload($addressId, $customerId);
 
         $payload->setStreet($mergedStreet);
         $payload->setAdditionalAddressLine1('');


### PR DESCRIPTION
The AdditionalAddressFieldInStreetInsurance is using a CustomerAddressUpdatePayload without providing a customerId.
This causes an exception when using the plugin B2B Suite while APP_Debug is true.

This issue is fixed by providing a customerId from the addressEntity, that is already available.

Ref: DEV-582