### PR TITLE
Fix circular reference error in serialization of webhook payload

### DIFF
--- a/src/Entity/EnderecoAddressExtension/EnderecoBaseAddressExtensionEntity.php
+++ b/src/Entity/EnderecoAddressExtension/EnderecoBaseAddressExtensionEntity.php
@@ -320,4 +320,17 @@ abstract class EnderecoBaseAddressExtensionEntity extends Entity
     {
         return str_contains($this->amsStatus, self::AMS_STATUS_SELECTED_BY_CUSTOMER);
     }
+
+    /**
+     * Unset 'address' to prevent circular references
+     * during serialization
+     *
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $vars = parent::jsonSerialize();
+        unset($vars['address']);
+        return $vars;
+    }
 }

--- a/tests/Unit/Entity/CustomerAddress/EnderecoCustomerAddressExtensionEntityTest.php
+++ b/tests/Unit/Entity/CustomerAddress/EnderecoCustomerAddressExtensionEntityTest.php
@@ -8,6 +8,7 @@
 
 namespace Endereco\Shopware6Client\Tests\Unit\Entity\CustomerAddress;
 
+use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionCollection;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
@@ -181,6 +182,33 @@ class EnderecoCustomerAddressExtensionEntityTest extends TestCase
         $this->assertTrue($collection->has($customUniqueId));
         $this->assertFalse($collection->has($addressId));
         $this->assertSame($extension, $collection->get($customUniqueId));
+    }
+
+    /**
+     * Tests that json_encode() does not fail with a circular reference error when
+     * the extension holds a back-reference to its parent CustomerAddressEntity.
+     *
+     * Without jsonSerialize() being overridden to exclude $address, json_encode()
+     * would detect the cycle CustomerAddressEntity → extension → CustomerAddressEntity
+     * and return false with JSON_ERROR_RECURSION.
+     */
+    public function testJsonEncodeDoesNotProduceCircularReferenceError(): void
+    {
+        $addressId = Uuid::randomHex();
+        $customerAddress = $this->createCustomerAddress($addressId);
+
+        $extension = EnderecoCustomerAddressExtensionEntity::createWithDefaultValues($customerAddress);
+
+        // Set up the circular reference that triggered the production bug:
+        // CustomerAddressEntity → EnderecoCustomerAddressExtensionEntity → CustomerAddressEntity
+        $extension->setAddress($customerAddress);
+        $customerAddress->addExtension(CustomerAddressExtension::ENDERECO_EXTENSION, $extension);
+
+        // Mirrors what Shopware's StructNormalizer::normalize() does during webhook serialization:
+        // Without a jsonSerialize() override this cycle causes JSON_ERROR_RECURSION.
+        $result = json_encode($customerAddress);
+        $this->assertNotFalse($result, 'json_encode($customerAddress) failed: ' . json_last_error_msg());
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
     }
 
     /**


### PR DESCRIPTION
If a customer manages to register without setting
the EnderecoCustomerAddressExtension,
the AddressExtensionExistsInsurance makes sure, that an extension with default values is added to the customer address in EnderecoCustomerAddressExtensionEntity::createWithDefaultValues().

Inside this function, a circular reference is established, by setting the current addressEntity as the address property
of the EnderecoCustomerAddressExtension.

When serialization of a webhook payload takes place, this causes a NotEncodableValueException, because
a recursion is detected.
As a result the webhook is not sent to the target system.

By overriding the jsonSerialize() function of the
EnderecoBaseAddressExtensionEntity, and unsetting
the address property, the circular reference is no longer present during serialization.

A new test case makes sure, that this error won't occur, on future refacturings.

Ref: DEV-650