### PR TITLE
Invalidate extension data for changed order addresses

### DIFF
--- a/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
+++ b/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
@@ -287,7 +287,7 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
     protected function extractSplitAddressFromOrderAddress(OrderAddressEntity $address, Context $context): ?array
     {
         $extension = $address->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
-        
+
         // If extension is not loaded, try to load it from database
         if (!$extension instanceof EnderecoOrderAddressExtensionEntity) {
             $versionId = $address->getVersionId();
@@ -295,7 +295,7 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
                 $extension = $this->loadOrderAddressExtension($address->getId(), $versionId, $context);
             }
         }
-        
+
         if (!$extension instanceof EnderecoOrderAddressExtensionEntity) {
             return null;
         }
@@ -305,6 +305,16 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
 
         // Only return if we have at least the street name
         if (empty($streetName)) {
+            return null;
+        }
+
+        // A SplitStreetInsurance is not yet available for order addresses.
+        // So it must be evaluated wether the splitstreet cache is still up to date.
+        $currentStreet = mb_strtolower($address->getStreet());
+        $cacheStillMatches = str_contains($currentStreet, mb_strtolower($streetName))
+            && str_contains($currentStreet, mb_strtolower($houseNumber));
+
+        if (!$cacheStillMatches) {
             return null;
         }
 

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -220,6 +220,28 @@ class EnderecoService
             $addressEntity->getVersionId()
         );
 
+        $existingExtension = $addressEntity->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
+        if ($existingExtension instanceof EnderecoOrderAddressExtensionEntity) {
+            $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['id']
+                = $existingExtension->getId();
+            $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['versionId']
+                = $existingExtension->getVersionId();
+
+            // Keep the in-memory entity in sync with the reset values. Insurances running later in the
+            // same ensureAddressesIntegrity() read the extension
+            // straight off $addressEntity, and would otherwise still see the stale, pre-reset status
+            // until the address is loaded again in a separate request.
+            $existingExtension->setAmsRequestPayload($addressExtension->getAmsRequestPayload());
+            $existingExtension->setAmsStatus($addressExtension->getAmsStatus());
+            $existingExtension->setAmsPredictions($addressExtension->getAmsPredictions());
+            $existingExtension->setAmsTimestamp($addressExtension->getAmsTimestamp());
+            $existingExtension->setStreet($addressExtension->getStreet());
+            $existingExtension->setHouseNumber($addressExtension->getHouseNumber());
+        } else {
+            $addressEntity->addExtension(OrderAddressExtension::ENDERECO_EXTENSION, $addressExtension);
+        }
+
+        // Reset the values of the extension to their defaults
         $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['amsRequestPayload']
             = $addressExtension->getAmsRequestPayload();
         $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['amsStatus']
@@ -229,9 +251,11 @@ class EnderecoService
         $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['amsTimestamp']
             = $addressExtension->getAmsTimestamp();
 
-        // Update the customer address in the repository
-        // The update payload doesn't require an ID (and version ID) because it is persisted via the one-to-one
-        // relationship with the order address, which is unique.
+        $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['street']
+            = $addressExtension->getStreet();
+        $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['houseNumber']
+            = $addressExtension->getHouseNumber();
+
         $this->orderAddressRepository->update([$updatePayload], $context);
     }
 


### PR DESCRIPTION
Right now, only addresses that originate from the Storefront are being validated.

If an order address gets changed after the order address extension is written, it does not get re-validated.

To prevent displaying stale validation results, the extension of a modified order address, has to be reset.

When enderecoSplitStreetAndHouseNumber is active, the cached street and housenumber of the extension is used to build the check payload.
As there is no SplitStreetInsurance for order addresses, we check wether the changed address contains the cached street.

Ref: DEV-676