### PR TITLE
Store salesChannelId in OrderAddressExtension

### DIFF
--- a/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionDefinition.php
+++ b/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionDefinition.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
 /**
  * Class EnderecoOrderAddressExtensionDefinition
@@ -96,6 +97,10 @@ class EnderecoOrderAddressExtensionDefinition extends EnderecoBaseAddressExtensi
         $referenceVersionField = new ReferenceVersionField(OrderAddressDefinition::class, 'address_version_id');
         $referenceVersionField->addFlags(new Required());
         $fields->add($referenceVersionField);
+
+        // Store the salesChannelId of the order's origin, so it's available during operations
+        // that don't have a SalesChannelContext, e.g the IntegrityInsurance chain
+        $fields->add(new FkField('sales_channel_id', 'salesChannelId', SalesChannelDefinition::class));
 
         return $fields;
     }

--- a/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionEntity.php
+++ b/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionEntity.php
@@ -35,6 +35,9 @@ class EnderecoOrderAddressExtensionEntity extends EnderecoBaseAddressExtensionEn
     /** @var ?OrderAddressEntity The associated order address entity. */
     protected ?OrderAddressEntity $address = null;
 
+    /** @var string|null The sales channel ID this order address' order belongs to. */
+    protected ?string $salesChannelId = null;
+
     /**
      * Creates an order address extension instance with a random UUID and the default AMS data.
      * An order address ID is mandatory. An order address version ID is optional.
@@ -97,6 +100,26 @@ class EnderecoOrderAddressExtensionEntity extends EnderecoBaseAddressExtensionEn
     public function setAddressVersionId(string $addressId): void
     {
         $this->addressVersionId = $addressId;
+    }
+
+    /**
+     * Get the sales channel ID this order address' order belongs to.
+     *
+     * @return string|null
+     */
+    public function getSalesChannelId(): ?string
+    {
+        return $this->salesChannelId;
+    }
+
+    /**
+     * Set the sales channel ID this order address' order belongs to.
+     *
+     * @param string|null $salesChannelId
+     */
+    public function setSalesChannelId(?string $salesChannelId): void
+    {
+        $this->salesChannelId = $salesChannelId;
     }
 
     /**

--- a/src/Migration/Migration1784722853AddSalesChannelIdToOrderAddressExtension.php
+++ b/src/Migration/Migration1784722853AddSalesChannelIdToOrderAddressExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * Adds a sales_channel_id column to endereco_order_address_ext_gh so the sales channel an order
+ * address belongs to can be cached once at creation time, instead of having to be re-resolved via
+ * an extra query on every later load (order_address's own "order" association is not autoloaded).
+ */
+class Migration1784722853AddSalesChannelIdToOrderAddressExtension extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1784722853;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @throws Exception
+     */
+    public function update(Connection $connection): void
+    {
+        $columnExists = (int) $connection->fetchOne(
+            <<<SQL
+            SELECT COUNT(*)
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = :database
+                AND TABLE_NAME = 'endereco_order_address_ext_gh'
+                AND COLUMN_NAME = 'sales_channel_id'
+            SQL,
+            ['database' => $connection->getDatabase()]
+        ) > 0;
+
+        if (!$columnExists) {
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `endereco_order_address_ext_gh`
+                    ADD COLUMN `sales_channel_id` BINARY(16) NULL AFTER `address_version_id`
+                SQL
+            );
+        }
+
+        $constraintExists = (int) $connection->fetchOne(
+            <<<SQL
+            SELECT COUNT(*)
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = :database
+                AND TABLE_NAME = 'endereco_order_address_ext_gh'
+                AND CONSTRAINT_NAME = 'fk.endereco_order_address_ext_gh.sales_channel_id'
+            SQL,
+            ['database' => $connection->getDatabase()]
+        ) > 0;
+
+        if (!$constraintExists) {
+            // ON DELETE SET NULL, not CASCADE: this column is only a cache to avoid re-resolving the
+            // sales channel on every load - unlike address_id, it is not essential to this row's
+            // identity, so a deleted sales channel should just clear the reference, not the whole row.
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `endereco_order_address_ext_gh`
+                    ADD CONSTRAINT `fk.endereco_order_address_ext_gh.sales_channel_id`
+                    FOREIGN KEY (`sales_channel_id`)
+                    REFERENCES `sales_channel` (`id`)
+                    ON DELETE SET NULL
+                SQL
+            );
+        }
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Migration/Migration1784722853AddSalesChannelIdToOrderAddressExtension.php
+++ b/src/Migration/Migration1784722853AddSalesChannelIdToOrderAddressExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * Adds a sales_channel_id column to endereco_order_address_ext_gh so the sales channel an order
+ * address belongs to can be cached once at creation time, instead of having to be re-resolved via
+ * an extra query on every later load (order_address's own "order" association is not autoloaded).
+ */
+class Migration1784722853AddSalesChannelIdToOrderAddressExtension extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1784722853;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @throws Exception
+     */
+    public function update(Connection $connection): void
+    {
+        $columnExists = (int) $connection->fetchOne(
+                <<<SQL
+            SELECT COUNT(*)
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = :database
+                AND TABLE_NAME = 'endereco_order_address_ext_gh'
+                AND COLUMN_NAME = 'sales_channel_id'
+            SQL,
+                ['database' => $connection->getDatabase()]
+            ) > 0;
+
+        if (!$columnExists) {
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `endereco_order_address_ext_gh`
+                    ADD COLUMN `sales_channel_id` BINARY(16) NULL AFTER `address_version_id`
+                SQL
+            );
+        }
+
+        $constraintExists = (int) $connection->fetchOne(
+                <<<SQL
+            SELECT COUNT(*)
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = :database
+                AND TABLE_NAME = 'endereco_order_address_ext_gh'
+                AND CONSTRAINT_NAME = 'fk.endereco_order_address_ext_gh.sales_channel_id'
+            SQL,
+                ['database' => $connection->getDatabase()]
+            ) > 0;
+
+        if (!$constraintExists) {
+            // ON DELETE SET NULL, not CASCADE: this column is only a cache to avoid re-resolving the
+            // sales channel on every load - unlike address_id, it is not essential to this row's
+            // identity, so a deleted sales channel should just clear the reference, not the whole row.
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `endereco_order_address_ext_gh`
+                    ADD CONSTRAINT `fk.endereco_order_address_ext_gh.sales_channel_id`
+                    FOREIGN KEY (`sales_channel_id`)
+                    REFERENCES `sales_channel` (`id`)
+                    ON DELETE SET NULL
+                SQL
+            );
+        }
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Subscriber/ConvertCartToOrderSubscriber.php
+++ b/src/Subscriber/ConvertCartToOrderSubscriber.php
@@ -139,6 +139,11 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
                 // Shopware will automatically do that and use the relation to set it in the extension as well.
 
                 $orderAddressExtensionEntity = $customerAddressExtension->createOrderAddressExtension($orderAddressId);
+
+                // Save the salesChannelId here since we already have it in the context - avoids having to
+                // resolve it again via an extra query on every later load of this order address
+                // during the IntegrityInsurances.
+                $orderAddressExtensionEntity->setSalesChannelId($context->getSalesChannelId());
                 $orderAddressExtensionData = $orderAddressExtensionEntity->buildCartToOrderConversionData();
                 $address[OrderAddressExtension::ENDERECO_EXTENSION] = $orderAddressExtensionData;
             }


### PR DESCRIPTION
In order to properly read the plugin's system config,
for each saleschannel a salesChannelId is required.

In a storefront context this isn't a problem.
But since the IntegrityInsurances for OrderAddressExtensions
don't have a storefront context, there is no simple way
to retrieve a salesChannelId during their execution.

To solve this problem, we add a new salesChannelId property
to the OrderAddressExtension.
Since the extension is only ever written on a completed
storefront checkout, the already available salesChannelId
is simply added to the extension when the CustomAddressExtension
is copied. That way, the salesChannelId can simply be read
from the OrderAddressExtension itself.

Ref: DEV-735
