### PR TITLE
Re-enable writing OrderAddressExtension on checkout

### DIFF
--- a/src/Subscriber/ConvertCartToOrderSubscriber.php
+++ b/src/Subscriber/ConvertCartToOrderSubscriber.php
@@ -64,15 +64,15 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
      */
     public function copyEnderecoAddressExtension(CartConvertedEvent $event): void
     {
-        // TODO: Temporarily disabled due to order address handling bug - re-enable after tests pass
-        return;
-
-        // @phpstan-ignore-next-line Deadcode.UnreachableStatement
         $convertedCart = $event->getConvertedCart();
 
         if (isset($convertedCart['addresses']) && is_array($convertedCart['addresses'])) {
             foreach ($convertedCart['addresses'] as $key => $address) {
-                $this->amendOrderAddressData($address, $event->getCart(), $event->getSalesChannelContext());
+                $this->amendOrderAddressData(
+                    $address,
+                    $event->getCart(),
+                    $event->getSalesChannelContext()
+                );
                 $convertedCart['addresses'][$key] = $address;
             }
         }
@@ -105,7 +105,6 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
      * @param SalesChannelContext $context The sales channel context
      * @return void
      */
-    // @phpstan-ignore-next-line UnusedPrivateMethod
     private function amendOrderAddressData(array &$address, Cart $cart, SalesChannelContext $context): void
     {
         $matchingCustomerAddresses = $this->addressDataMatcher->findCustomerAddressesForOrderAddressDataInCart(


### PR DESCRIPTION
Re-enable writing OrderAddressExtension on checkout

In order to keep the result of the address check available after the checkout is finished, the current CustomerAddressExtension is copied into the OrderAddressExtension when the cart is converted to an order.

For that the CartConvertedEvent is used, because at this point, the CustomerAddressExtension has already been written, with validated address data.

Ref: DEV-675