### PR TITLE
Prepare infrastructure for custom logging

### DIFF
--- a/src/Resources/config/packages/monolog.yaml
+++ b/src/Resources/config/packages/monolog.yaml
@@ -1,2 +1,21 @@
 monolog:
     channels: ['endereco_shopware6_client']
+    handlers:
+        endereco_main_alias:
+            type: service
+            id: monolog.handler.main
+        endereco_shopware6_client_critical_escalation:
+            type: filter
+            handler: endereco_main_alias
+            min_level: critical
+            channels: ['endereco_shopware6_client']
+            priority: 20
+            bubble: true
+        endereco_shopware6_client:
+            type: rotating_file
+            path: "%kernel.logs_dir%/endereco_shopware6_client_%kernel.environment%.log"
+            max_files: 30
+            level: warning
+            channels: ['endereco_shopware6_client']
+            priority: 10
+            bubble: false


### PR DESCRIPTION
Logging inside the plugin is not consistent.
Serverside services use a non-persistent in-memory logger, while the ProxyController uses the Shopware standard logger.

A consequence of this, is that the Shopware standard log, contains lots of entries related to our plugin, that might not be as relevant as they imply.
On the other hand, information that can be useful
for debugging, is never stored persistantly.

In order to get consistent logging behaviour and keep the Shopware standard log clean, we use our own
channel handler, that writes a rotating file log, and only escalates log entries with a severity of critical or higher to the Shopware standard log.

In this first step, the handler is configured, so in the next steps, the existing loggers can be replaced with it.

Ref: DEV-715