### PR TITLE
Route EnderecoApiProxyController logs to own channel logger

### DIFF
--- a/src/Resources/config/services/controller.php
+++ b/src/Resources/config/services/controller.php
@@ -8,7 +8,6 @@ use Endereco\Shopware6Client\Controller\Storefront\AddressController;
 use Endereco\Shopware6Client\Service\ApiConfiguration\ApiConfigurationFetcherInterface;
 use Endereco\Shopware6Client\Service\EnderecoService;
 use Endereco\Shopware6Client\Service\SessionManagementService;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -45,7 +44,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             '$httpClient' => service('endereco.http_client'),
             '$apiConfigurationFetcher' => service(ApiConfigurationFetcherInterface::class),
-            '$logger' => service(LoggerInterface::class),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ])
         ->tag('controller.service_arguments')
         ->public();


### PR DESCRIPTION
EnderecoApiProxyController writes its log entries into Shopware's standard log. This happens because of its DI configuration, where it receives Psr\Log\LoggerInterface as its logger service — which resolves to Shopware's default logger, not ours.

To keep Endereco log entries out of the standard log and route them into our own logfile, the DI configuration now passes monolog.logger.endereco_shopware6_client instead.

Ref: DEV-721