### PR TITLE
Route logs of serverside services to own channel logger

### DIFF
--- a/src/Resources/config/services/service.php
+++ b/src/Resources/config/services/service.php
@@ -58,7 +58,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$requestHeadersGenerator' => service(RequestHeadersGeneratorInterface::class),
             '$payloadPreparator' => service(PayloadPreparatorInterface::class),
             '$requestStack' => service('request_stack'),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ]);
 
     $services->set(BySystemConfigFilter::class)
@@ -83,7 +83,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$extensionEntityUpdater' => service(EnderecoExtensionEntityUpdater::class),
             '$arrayUpdater' => service(AddressAsArrayUpdater::class),
             '$extensionArrayUpdater' => service(AddressExtensionAsArrayUpdater::class),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
             '$pluginStatusService' => service(\Endereco\Shopware6Client\Service\PluginStatusService::class),
         ])
         ->public();

--- a/src/Resources/config/services/service_address_check.php
+++ b/src/Resources/config/services/service_address_check.php
@@ -43,7 +43,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$requestHeadersGenerator' => service(RequestHeadersGeneratorInterface::class),
             '$addressCheckPayloadBuilder' => service(AddressCheckPayloadBuilderInterface::class),
             '$payloadPreparator' => service(PayloadPreparatorInterface::class),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ]);
     $services->set(AddressCheckerWithCache::class)
         ->args([

--- a/src/Resources/config/services/service_address_correction.php
+++ b/src/Resources/config/services/service_address_correction.php
@@ -40,7 +40,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$systemConfigService' => service(SystemConfigService::class),
             '$requestHeadersGenerator' => service(RequestHeadersGeneratorInterface::class),
             '$payloadPreparator' => service(PayloadPreparatorInterface::class),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ]);
     $services->set(StreetSplitterWithCache::class)
         ->args([


### PR DESCRIPTION
Serverside services currently log through the custom service Endereco\Shopware6Client\Run\Logger. That service only has an in-memory handler attached — nothing is ever persisted, and nothing reads the buffered entries back out, so every log call from these four classes effectively disappears at the end of the request.

Switch to monolog.logger.endereco_shopware6_client so their log entries are written into our own logfile instead of vanishing silently.

Ref: DEV-722