### PR TITLE
Invalidate extension data for changed order addresses

### DIFF
--- a/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionDefinition.php
+++ b/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionDefinition.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
 /**
  * Class EnderecoOrderAddressExtensionDefinition
@@ -96,6 +97,10 @@ class EnderecoOrderAddressExtensionDefinition extends EnderecoBaseAddressExtensi
         $referenceVersionField = new ReferenceVersionField(OrderAddressDefinition::class, 'address_version_id');
         $referenceVersionField->addFlags(new Required());
         $fields->add($referenceVersionField);
+
+        // Store the salesChannelId of the order's origin, so it's available during operations
+        // that don't have a SalesChannelContext, e.g the IntegrityInsurance chain
+        $fields->add(new FkField('sales_channel_id', 'salesChannelId', SalesChannelDefinition::class));
 
         return $fields;
     }

--- a/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionEntity.php
+++ b/src/Entity/EnderecoAddressExtension/OrderAddress/EnderecoOrderAddressExtensionEntity.php
@@ -35,6 +35,9 @@ class EnderecoOrderAddressExtensionEntity extends EnderecoBaseAddressExtensionEn
     /** @var ?OrderAddressEntity The associated order address entity. */
     protected ?OrderAddressEntity $address = null;
 
+    /** @var string|null The sales channel ID this order address' order belongs to. */
+    protected ?string $salesChannelId = null;
+
     /**
      * Creates an order address extension instance with a random UUID and the default AMS data.
      * An order address ID is mandatory. An order address version ID is optional.
@@ -97,6 +100,26 @@ class EnderecoOrderAddressExtensionEntity extends EnderecoBaseAddressExtensionEn
     public function setAddressVersionId(string $addressId): void
     {
         $this->addressVersionId = $addressId;
+    }
+
+    /**
+     * Get the sales channel ID this order address' order belongs to.
+     *
+     * @return string|null
+     */
+    public function getSalesChannelId(): ?string
+    {
+        return $this->salesChannelId;
+    }
+
+    /**
+     * Set the sales channel ID this order address' order belongs to.
+     *
+     * @param string|null $salesChannelId
+     */
+    public function setSalesChannelId(?string $salesChannelId): void
+    {
+        $this->salesChannelId = $salesChannelId;
     }
 
     /**

--- a/src/Migration/Migration1784722853AddSalesChannelIdToOrderAddressExtension.php
+++ b/src/Migration/Migration1784722853AddSalesChannelIdToOrderAddressExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Endereco\Shopware6Client\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * Adds a sales_channel_id column to endereco_order_address_ext_gh so the sales channel an order
+ * address belongs to can be cached once at creation time, instead of having to be re-resolved via
+ * an extra query on every later load (order_address's own "order" association is not autoloaded).
+ */
+class Migration1784722853AddSalesChannelIdToOrderAddressExtension extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1784722853;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @throws Exception
+     */
+    public function update(Connection $connection): void
+    {
+        $columnExists = (int) $connection->fetchOne(
+            <<<SQL
+            SELECT COUNT(*)
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = :database
+                AND TABLE_NAME = 'endereco_order_address_ext_gh'
+                AND COLUMN_NAME = 'sales_channel_id'
+            SQL,
+            ['database' => $connection->getDatabase()]
+        ) > 0;
+
+        if (!$columnExists) {
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `endereco_order_address_ext_gh`
+                    ADD COLUMN `sales_channel_id` BINARY(16) NULL AFTER `address_version_id`
+                SQL
+            );
+        }
+
+        $constraintExists = (int) $connection->fetchOne(
+            <<<SQL
+            SELECT COUNT(*)
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = :database
+                AND TABLE_NAME = 'endereco_order_address_ext_gh'
+                AND CONSTRAINT_NAME = 'fk.endereco_order_address_ext_gh.sales_channel_id'
+            SQL,
+            ['database' => $connection->getDatabase()]
+        ) > 0;
+
+        if (!$constraintExists) {
+            // ON DELETE SET NULL, not CASCADE: this column is only a cache to avoid re-resolving the
+            // sales channel on every load - unlike address_id, it is not essential to this row's
+            // identity, so a deleted sales channel should just clear the reference, not the whole row.
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `endereco_order_address_ext_gh`
+                    ADD CONSTRAINT `fk.endereco_order_address_ext_gh.sales_channel_id`
+                    FOREIGN KEY (`sales_channel_id`)
+                    REFERENCES `sales_channel` (`id`)
+                    ON DELETE SET NULL
+                SQL
+            );
+        }
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -232,6 +232,23 @@
                 Dies kann die Datenqualität verbessern, könnte aber den Importvorgang verlangsamen.
             </helpText>
         </input-field>
+
+        <input-field type="bool">
+            <name>enderecoCopyExtensionIntoOrderAddress</name>
+            <label>Copy data of the address check into the order address</label>
+            <label lang="de-DE">Kopieren der Daten der Adressprüfung in die Bestelladresse</label>
+            <defaultValue>false</defaultValue>
+            <helpText>
+                If enabled, the result of the address validation is copied into the order address on order finish.
+                Relevant data like status of the check, street and housenumber stays available this way
+                and can be accessed by association of the order address extension.
+            </helpText>
+            <helpText lang="de-DE">
+                Wenn aktiviert, wird das Ergebnis der Adressprüfung bei Bestellabschluss in die Bestelladresse kopiert.
+                Relevante Daten, wie Status der Prüfung, Straße und Hausnummer bleiben somit erhalten
+                und können über Association auf die Order Address Extension gelesen werden.
+            </helpText>
+        </input-field>
     </card>
 
     <card>

--- a/src/Resources/config/packages/monolog.yaml
+++ b/src/Resources/config/packages/monolog.yaml
@@ -1,2 +1,21 @@
 monolog:
     channels: ['endereco_shopware6_client']
+    handlers:
+        endereco_main_alias:
+            type: service
+            id: monolog.handler.main
+        endereco_shopware6_client_critical_escalation:
+            type: filter
+            handler: endereco_main_alias
+            min_level: critical
+            channels: ['endereco_shopware6_client']
+            priority: 20
+            bubble: true
+        endereco_shopware6_client:
+            type: rotating_file
+            path: "%kernel.logs_dir%/endereco_shopware6_client_%kernel.environment%.log"
+            max_files: 30
+            level: warning
+            channels: ['endereco_shopware6_client']
+            priority: 10
+            bubble: false

--- a/src/Resources/config/services/controller.php
+++ b/src/Resources/config/services/controller.php
@@ -8,7 +8,6 @@ use Endereco\Shopware6Client\Controller\Storefront\AddressController;
 use Endereco\Shopware6Client\Service\ApiConfiguration\ApiConfigurationFetcherInterface;
 use Endereco\Shopware6Client\Service\EnderecoService;
 use Endereco\Shopware6Client\Service\SessionManagementService;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -45,7 +44,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             '$httpClient' => service('endereco.http_client'),
             '$apiConfigurationFetcher' => service(ApiConfigurationFetcherInterface::class),
-            '$logger' => service(LoggerInterface::class),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ])
         ->tag('controller.service_arguments')
         ->public();

--- a/src/Resources/config/services/service.php
+++ b/src/Resources/config/services/service.php
@@ -58,7 +58,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$requestHeadersGenerator' => service(RequestHeadersGeneratorInterface::class),
             '$payloadPreparator' => service(PayloadPreparatorInterface::class),
             '$requestStack' => service('request_stack'),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ]);
 
     $services->set(BySystemConfigFilter::class)
@@ -83,7 +83,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$extensionEntityUpdater' => service(EnderecoExtensionEntityUpdater::class),
             '$arrayUpdater' => service(AddressAsArrayUpdater::class),
             '$extensionArrayUpdater' => service(AddressExtensionAsArrayUpdater::class),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
             '$pluginStatusService' => service(\Endereco\Shopware6Client\Service\PluginStatusService::class),
         ])
         ->public();

--- a/src/Resources/config/services/service_address_check.php
+++ b/src/Resources/config/services/service_address_check.php
@@ -43,7 +43,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$requestHeadersGenerator' => service(RequestHeadersGeneratorInterface::class),
             '$addressCheckPayloadBuilder' => service(AddressCheckPayloadBuilderInterface::class),
             '$payloadPreparator' => service(PayloadPreparatorInterface::class),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ]);
     $services->set(AddressCheckerWithCache::class)
         ->args([

--- a/src/Resources/config/services/service_address_correction.php
+++ b/src/Resources/config/services/service_address_correction.php
@@ -40,7 +40,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '$systemConfigService' => service(SystemConfigService::class),
             '$requestHeadersGenerator' => service(RequestHeadersGeneratorInterface::class),
             '$payloadPreparator' => service(PayloadPreparatorInterface::class),
-            '$logger' => service('Endereco\Shopware6Client\Run\Logger'),
+            '$logger' => service('monolog.logger.endereco_shopware6_client'),
         ]);
     $services->set(StreetSplitterWithCache::class)
         ->args([

--- a/src/Resources/config/services/subscriber.php
+++ b/src/Resources/config/services/subscriber.php
@@ -49,8 +49,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(ConvertCartToOrderSubscriber::class)
         ->args([
-            '$orderAddressToCustomerAddressDataMatcher'
-                => service(OrderAddressToCustomerAddressDataMatcherInterface::class),
+            '$orderAddressToCustomerAddressDataMatcher' => service(OrderAddressToCustomerAddressDataMatcherInterface::class),
+            '$enderecoService' => service(EnderecoService::class),
         ])
         ->tag('kernel.event_subscriber');
 
@@ -77,6 +77,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(OrderAddressSubscriber::class)
         ->args([
             '$orderAddressIntegrityInsurance' => service(OrderAddressIntegrityInsuranceInterface::class),
+            '$enderecoService' => service(EnderecoService::class),
         ])
         ->tag('kernel.event_subscriber');
 };

--- a/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
+++ b/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
@@ -287,7 +287,7 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
     protected function extractSplitAddressFromOrderAddress(OrderAddressEntity $address, Context $context): ?array
     {
         $extension = $address->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
-        
+
         // If extension is not loaded, try to load it from database
         if (!$extension instanceof EnderecoOrderAddressExtensionEntity) {
             $versionId = $address->getVersionId();
@@ -295,7 +295,7 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
                 $extension = $this->loadOrderAddressExtension($address->getId(), $versionId, $context);
             }
         }
-        
+
         if (!$extension instanceof EnderecoOrderAddressExtensionEntity) {
             return null;
         }
@@ -305,6 +305,16 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
 
         // Only return if we have at least the street name
         if (empty($streetName)) {
+            return null;
+        }
+
+        // A SplitStreetInsurance is not yet available for order addresses.
+        // So it must be evaluated wether the splitstreet cache is still up to date.
+        $currentStreet = mb_strtolower($address->getStreet());
+        $cacheStillMatches = str_contains($currentStreet, mb_strtolower($streetName))
+            && str_contains($currentStreet, mb_strtolower($houseNumber));
+
+        if (!$cacheStillMatches) {
             return null;
         }
 

--- a/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
+++ b/src/Service/AddressCheck/AddressCheckPayloadBuilder.php
@@ -310,9 +310,15 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
 
         // A SplitStreetInsurance is not yet available for order addresses.
         // So it must be evaluated wether the splitstreet cache is still up to date.
-        $currentStreet = mb_strtolower($address->getStreet());
-        $cacheStillMatches = str_contains($currentStreet, mb_strtolower($streetName))
-            && str_contains($currentStreet, mb_strtolower($houseNumber));
+        // The street name and house number order in the full address string is country-dependent
+        // (e.g. "Musterstraße 12" in Germany vs. "12 Rue de la Paix" in France), so both orders
+        // are accepted here instead of assuming a fixed one.
+        $currentStreet = $this->normalizeStreetForComparison($address->getStreet());
+        $expectedStreetNameFirst = $this->normalizeStreetForComparison(trim($streetName . ' ' . $houseNumber));
+        $expectedHouseNumberFirst = $this->normalizeStreetForComparison(trim($houseNumber . ' ' . $streetName));
+
+        $cacheStillMatches = $currentStreet === $expectedStreetNameFirst
+            || $currentStreet === $expectedHouseNumberFirst;
 
         if (!$cacheStillMatches) {
             return null;
@@ -697,5 +703,17 @@ final class AddressCheckPayloadBuilder implements AddressCheckPayloadBuilderInte
         
         $entity = $result->first();
         return $entity instanceof EnderecoOrderAddressExtensionEntity ? $entity : null;
+    }
+
+    /**
+     * Normalizes a street string for comparison: lowercases, collapses any run of
+     * whitespace into a single space, and trims the ends.
+     *
+     * @param string $value Street string to normalize
+     * @return string Normalized street string
+     */
+    private function normalizeStreetForComparison(string $value): string
+    {
+        return trim((string) preg_replace('/\s+/u', ' ', mb_strtolower($value)));
     }
 }

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -220,6 +220,28 @@ class EnderecoService
             $addressEntity->getVersionId()
         );
 
+        $existingExtension = $addressEntity->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
+        if ($existingExtension instanceof EnderecoOrderAddressExtensionEntity) {
+            $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['id']
+                = $existingExtension->getId();
+            $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['versionId']
+                = $existingExtension->getVersionId();
+
+            // Keep the in-memory entity in sync with the reset values. Insurances running later in the
+            // same ensureAddressesIntegrity() read the extension
+            // straight off $addressEntity, and would otherwise still see the stale, pre-reset status
+            // until the address is loaded again in a separate request.
+            $existingExtension->setAmsRequestPayload($addressExtension->getAmsRequestPayload());
+            $existingExtension->setAmsStatus($addressExtension->getAmsStatus());
+            $existingExtension->setAmsPredictions($addressExtension->getAmsPredictions());
+            $existingExtension->setAmsTimestamp($addressExtension->getAmsTimestamp());
+            $existingExtension->setStreet($addressExtension->getStreet());
+            $existingExtension->setHouseNumber($addressExtension->getHouseNumber());
+        } else {
+            $addressEntity->addExtension(OrderAddressExtension::ENDERECO_EXTENSION, $addressExtension);
+        }
+
+        // Reset the values of the extension to their defaults
         $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['amsRequestPayload']
             = $addressExtension->getAmsRequestPayload();
         $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['amsStatus']
@@ -229,9 +251,11 @@ class EnderecoService
         $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['amsTimestamp']
             = $addressExtension->getAmsTimestamp();
 
-        // Update the customer address in the repository
-        // The update payload doesn't require an ID (and version ID) because it is persisted via the one-to-one
-        // relationship with the order address, which is unique.
+        $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['street']
+            = $addressExtension->getStreet();
+        $updatePayload['extensions'][OrderAddressExtension::ENDERECO_EXTENSION]['houseNumber']
+            = $addressExtension->getHouseNumber();
+
         $this->orderAddressRepository->update([$updatePayload], $context);
     }
 

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -826,6 +826,41 @@ class EnderecoService
     }
 
     /**
+     * Checks whether the 'Copy data of the address check into the order address' feature is enabled.
+     *
+     * This method accepts a sales channel ID and checks two conditions:
+     * 1. Whether the Endereco plugin is active and ready to use for the given sales channel.
+     * 2. Whether the 'Copy data of the address check into the order address' feature
+     * is enabled in the settings for the given sales channel.
+     *
+     * The feature is considered active if both conditions are true. The method then returns this status.
+     *
+     * This feature is used to decide whether the result of the address check should be copied
+     * from the CustomerAddressExtension into the OrderAddressExtension on order finish and
+     * wether IntegrityInsurances should by applied to OrderAddressExtensions.
+     * It can be controlled via the EnderecoShopware6Client configuration, providing flexibility to meet different
+     * shop requirements.
+     *
+     * @param string $salesChannelId The ID of the sales channel for which to check the status of the feature.
+     *
+     * @return bool Returns true if the feature is enabled, false otherwise.
+     */
+    public function isUseOrderAddressExtensionFeatureEnabled(string $salesChannelId): bool
+    {
+        // Check if the Endereco plugin is active and ready to use for the given sales channel.
+        $pluginIsReadyToUse = $this->isEnderecoPluginActive($salesChannelId);
+
+        // Check if the order address extension feature is active in the settings for the given sales channel.
+        $featureIsActiveInSettings = $this->systemConfigService
+            ->getBool('EnderecoShopware6Client.config.enderecoCopyExtensionIntoOrderAddress', $salesChannelId);
+
+        // The feature is active if both the plugin is ready to use and the feature is active in settings.
+        $featureIsActive = $pluginIsReadyToUse && $featureIsActiveInSettings;
+
+        return $featureIsActive;
+    }
+
+    /**
      * Checks whether the given address is from a remote source.
      *
      * This method accepts a CustomerAddressEntity and retrieves the corresponding

--- a/src/Subscriber/ConvertCartToOrderSubscriber.php
+++ b/src/Subscriber/ConvertCartToOrderSubscriber.php
@@ -5,6 +5,7 @@ namespace Endereco\Shopware6Client\Subscriber;
 use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
+use Endereco\Shopware6Client\Service\EnderecoService;
 use Endereco\Shopware6Client\Service\OrderAddressToCustomerAddressDataMatcherInterface;
 use Endereco\Shopware6Client\Struct\OrderAddressDataForComparison;
 use Shopware\Core\Checkout\Cart\Cart;
@@ -30,15 +31,22 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
     private OrderAddressToCustomerAddressDataMatcherInterface $addressDataMatcher;
 
     /**
+     * @var EnderecoService
+     */
+    private EnderecoService $enderecoService;
+
+    /**
      * Initializes the subscriber with required dependencies.
      *
      * @param OrderAddressToCustomerAddressDataMatcherInterface $orderAddressToCustomerAddressDataMatcher
-     *                                                                                  Service for matching addresses
+     * @param EnderecoService $enderecoService
      */
     public function __construct(
-        OrderAddressToCustomerAddressDataMatcherInterface $orderAddressToCustomerAddressDataMatcher
+        OrderAddressToCustomerAddressDataMatcherInterface $orderAddressToCustomerAddressDataMatcher,
+        EnderecoService $enderecoService
     ) {
         $this->addressDataMatcher = $orderAddressToCustomerAddressDataMatcher;
+        $this->enderecoService = $enderecoService;
     }
 
     /**
@@ -64,6 +72,11 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
      */
     public function copyEnderecoAddressExtension(CartConvertedEvent $event): void
     {
+        $salesChannelId = $event->getSalesChannelContext()->getSalesChannelId();
+        if (!$this->enderecoService->isUseOrderAddressExtensionFeatureEnabled($salesChannelId)) {
+            return;
+        }
+
         $convertedCart = $event->getConvertedCart();
 
         if (isset($convertedCart['addresses']) && is_array($convertedCart['addresses'])) {

--- a/src/Subscriber/ConvertCartToOrderSubscriber.php
+++ b/src/Subscriber/ConvertCartToOrderSubscriber.php
@@ -139,6 +139,11 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
                 // Shopware will automatically do that and use the relation to set it in the extension as well.
 
                 $orderAddressExtensionEntity = $customerAddressExtension->createOrderAddressExtension($orderAddressId);
+
+                // Save the salesChannelId here since we already have it in the context - avoids having to
+                // resolve it again via an extra query on every later load of this order address
+                // during the IntegrityInsurances.
+                $orderAddressExtensionEntity->setSalesChannelId($context->getSalesChannelId());
                 $orderAddressExtensionData = $orderAddressExtensionEntity->buildCartToOrderConversionData();
                 $address[OrderAddressExtension::ENDERECO_EXTENSION] = $orderAddressExtensionData;
             }

--- a/src/Subscriber/OrderAddressSubscriber.php
+++ b/src/Subscriber/OrderAddressSubscriber.php
@@ -5,6 +5,7 @@ namespace Endereco\Shopware6Client\Subscriber;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
 use Endereco\Shopware6Client\Service\AddressIntegrity\OrderAddressIntegrityInsuranceInterface;
+use Endereco\Shopware6Client\Service\EnderecoService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\OrderEvents;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
@@ -12,12 +13,26 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class OrderAddressSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @var OrderAddressIntegrityInsuranceInterface
+     */
     private OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance;
 
+    /**
+     * @var EnderecoService
+     */
+    private EnderecoService $enderecoService;
+
+    /**
+     * @param OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance
+     * @param EnderecoService $enderecoService
+     */
     public function __construct(
-        OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance
+        OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance,
+        EnderecoService $enderecoService
     ) {
         $this->orderAddressIntegrityInsurance = $orderAddressIntegrityInsurance;
+        $this->enderecoService = $enderecoService;
     }
 
     public static function getSubscribedEvents(): array
@@ -54,15 +69,30 @@ class OrderAddressSubscriber implements EventSubscriberInterface
                 continue;
             }
 
+
             $addressKey = $entity->getId() . '-' . $entity->getVersionId();
             if (isset($processedAddresses[$addressKey])) {
                 continue;
             }
             $processedAddresses[$addressKey] = true;
 
-            //Skip the entity if it does not already have an EnderecoOrderAddressExtension
+            // Skip the entity if it does not already have an EnderecoOrderAddressExtension
             $addressExtension = $entity->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
             if (!$addressExtension instanceof EnderecoOrderAddressExtensionEntity) {
+                continue;
+            }
+
+            $orderSalesChannelId = $addressExtension->getSalesChannelId();
+            if (is_null($orderSalesChannelId)) {
+                continue;
+            }
+
+            $useOrderAddressExtensionEnabled =
+                $this->enderecoService->isUseOrderAddressExtensionFeatureEnabled($orderSalesChannelId);
+
+            // Skip the entity if the feature enderecoCopyExtensionIntoOrderAddress is disabled
+            // for its originating sales channel
+            if (!$useOrderAddressExtensionEnabled) {
                 continue;
             }
 


### PR DESCRIPTION
Right now, only addresses that originate from the Storefront are being validated.

If an order address gets changed after the order address extension is written, it does not get re-validated.

To prevent displaying stale validation results, the extension of a modified order address, has to be reset.

When enderecoSplitStreetAndHouseNumber is active, the cached street and housenumber of the extension is used to build the check payload.
As there is no SplitStreetInsurance for order addresses, we check wether the changed address contains the cached street.

Ref: DEV-676