### PR TITLE
Bind copy of CustomerAddressExtension to feature toggle

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -235,6 +235,23 @@
             </helpText>
         </input-field>
         -->
+        
+        <input-field type="bool">
+            <name>enderecoCopyExtensionIntoOrderAddress</name>
+            <label>Copy data of the address check into the order address</label>
+            <label lang="de-DE">Kopieren der Daten der Adressprüfung in die Bestelladresse</label>
+            <defaultValue>false</defaultValue>
+            <helpText>
+                If enabled, the result of the address validation is copied into the order address on order finish.
+                Relevant data like status of the check, street and housenumber stays available this way
+                and can be accessed by association of the order address extension.
+            </helpText>
+            <helpText lang="de-DE">
+                Wenn aktiviert, wird das Ergebnis der Adressprüfung bei Bestellabschluss in die Bestelladresse kopiert.
+                Relevante Daten, wie Status der Prüfung, Straße und Hausnummer bleiben somit erhalten
+                und können über Association auf die Order Address Extension gelesen werden.
+            </helpText>
+        </input-field>
     </card>
 
     <card>

--- a/src/Resources/config/services/subscriber.php
+++ b/src/Resources/config/services/subscriber.php
@@ -49,8 +49,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(ConvertCartToOrderSubscriber::class)
         ->args([
-            '$orderAddressToCustomerAddressDataMatcher'
-                => service(OrderAddressToCustomerAddressDataMatcherInterface::class),
+            '$orderAddressToCustomerAddressDataMatcher' => service(OrderAddressToCustomerAddressDataMatcherInterface::class),
+            '$enderecoService' => service(EnderecoService::class),
         ])
         ->tag('kernel.event_subscriber');
 
@@ -77,6 +77,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(OrderAddressSubscriber::class)
         ->args([
             '$orderAddressIntegrityInsurance' => service(OrderAddressIntegrityInsuranceInterface::class),
+            '$enderecoService' => service(EnderecoService::class),
         ])
         ->tag('kernel.event_subscriber');
 };

--- a/src/Service/EnderecoService.php
+++ b/src/Service/EnderecoService.php
@@ -837,6 +837,41 @@ class EnderecoService
     }
 
     /**
+     * Checks whether the 'Copy data of the address check into the order address' feature is enabled.
+     *
+     * This method accepts a sales channel ID and checks two conditions:
+     * 1. Whether the Endereco plugin is active and ready to use for the given sales channel.
+     * 2. Whether the 'Copy data of the address check into the order address' feature
+     * is enabled in the settings for the given sales channel.
+     *
+     * The feature is considered active if both conditions are true. The method then returns this status.
+     *
+     * This feature is used to decide whether the result of the address check should be copied
+     * from the CustomerAddressExtension into the OrderAddressExtension on order finish and
+     * wether IntegrityInsurances should by applied to OrderAddressExtensions.
+     * It can be controlled via the EnderecoShopware6Client configuration, providing flexibility to meet different
+     * shop requirements.
+     *
+     * @param string $salesChannelId The ID of the sales channel for which to check the status of the feature.
+     *
+     * @return bool Returns true if the feature is enabled, false otherwise.
+     */
+    public function isUseOrderAddressExtensionFeatureEnabled(string $salesChannelId): bool
+    {
+        // Check if the Endereco plugin is active and ready to use for the given sales channel.
+        $pluginIsReadyToUse = $this->isEnderecoPluginActive($salesChannelId);
+
+        // Check if the order address extension feature is active in the settings for the given sales channel.
+        $featureIsActiveInSettings = $this->systemConfigService
+            ->getBool('EnderecoShopware6Client.config.enderecoCopyExtensionIntoOrderAddress', $salesChannelId);
+
+        // The feature is active if both the plugin is ready to use and the feature is active in settings.
+        $featureIsActive = $pluginIsReadyToUse && $featureIsActiveInSettings;
+
+        return $featureIsActive;
+    }
+
+    /**
      * Checks whether the given address is from a remote source.
      *
      * This method accepts a CustomerAddressEntity and retrieves the corresponding

--- a/src/Subscriber/ConvertCartToOrderSubscriber.php
+++ b/src/Subscriber/ConvertCartToOrderSubscriber.php
@@ -5,6 +5,7 @@ namespace Endereco\Shopware6Client\Subscriber;
 use Endereco\Shopware6Client\Entity\CustomerAddress\CustomerAddressExtension;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\CustomerAddress\EnderecoCustomerAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
+use Endereco\Shopware6Client\Service\EnderecoService;
 use Endereco\Shopware6Client\Service\OrderAddressToCustomerAddressDataMatcherInterface;
 use Endereco\Shopware6Client\Struct\OrderAddressDataForComparison;
 use Shopware\Core\Checkout\Cart\Cart;
@@ -30,15 +31,22 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
     private OrderAddressToCustomerAddressDataMatcherInterface $addressDataMatcher;
 
     /**
+     * @var EnderecoService
+     */
+    private EnderecoService $enderecoService;
+
+    /**
      * Initializes the subscriber with required dependencies.
      *
      * @param OrderAddressToCustomerAddressDataMatcherInterface $orderAddressToCustomerAddressDataMatcher
-     *                                                                                  Service for matching addresses
+     * @param EnderecoService $enderecoService
      */
     public function __construct(
-        OrderAddressToCustomerAddressDataMatcherInterface $orderAddressToCustomerAddressDataMatcher
+        OrderAddressToCustomerAddressDataMatcherInterface $orderAddressToCustomerAddressDataMatcher,
+        EnderecoService $enderecoService
     ) {
         $this->addressDataMatcher = $orderAddressToCustomerAddressDataMatcher;
+        $this->enderecoService = $enderecoService;
     }
 
     /**
@@ -64,6 +72,11 @@ class ConvertCartToOrderSubscriber implements EventSubscriberInterface
      */
     public function copyEnderecoAddressExtension(CartConvertedEvent $event): void
     {
+        $salesChannelId = $event->getSalesChannelContext()->getSalesChannelId();
+        if (!$this->enderecoService->isUseOrderAddressExtensionFeatureEnabled($salesChannelId)) {
+            return;
+        }
+
         $convertedCart = $event->getConvertedCart();
 
         if (isset($convertedCart['addresses']) && is_array($convertedCart['addresses'])) {

--- a/src/Subscriber/OrderAddressSubscriber.php
+++ b/src/Subscriber/OrderAddressSubscriber.php
@@ -5,6 +5,7 @@ namespace Endereco\Shopware6Client\Subscriber;
 use Endereco\Shopware6Client\Entity\EnderecoAddressExtension\OrderAddress\EnderecoOrderAddressExtensionEntity;
 use Endereco\Shopware6Client\Entity\OrderAddress\OrderAddressExtension;
 use Endereco\Shopware6Client\Service\AddressIntegrity\OrderAddressIntegrityInsuranceInterface;
+use Endereco\Shopware6Client\Service\EnderecoService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\OrderEvents;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
@@ -12,12 +13,26 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class OrderAddressSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @var OrderAddressIntegrityInsuranceInterface
+     */
     private OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance;
 
+    /**
+     * @var EnderecoService
+     */
+    private EnderecoService $enderecoService;
+
+    /**
+     * @param OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance
+     * @param EnderecoService $enderecoService
+     */
     public function __construct(
-        OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance
+        OrderAddressIntegrityInsuranceInterface $orderAddressIntegrityInsurance,
+        EnderecoService $enderecoService
     ) {
         $this->orderAddressIntegrityInsurance = $orderAddressIntegrityInsurance;
+        $this->enderecoService = $enderecoService;
     }
 
     public static function getSubscribedEvents(): array
@@ -56,15 +71,30 @@ class OrderAddressSubscriber implements EventSubscriberInterface
                 continue;
             }
 
+
             $addressKey = $entity->getId() . '-' . $entity->getVersionId();
             if (isset($processedAddresses[$addressKey])) {
                 continue;
             }
             $processedAddresses[$addressKey] = true;
 
-            //Skip the entity if it does not already have an EnderecoOrderAddressExtension
+            // Skip the entity if it does not already have an EnderecoOrderAddressExtension
             $addressExtension = $entity->getExtension(OrderAddressExtension::ENDERECO_EXTENSION);
             if (!$addressExtension instanceof EnderecoOrderAddressExtensionEntity) {
+                continue;
+            }
+
+            $orderSalesChannelId = $addressExtension->getSalesChannelId();
+            if (is_null($orderSalesChannelId)) {
+                continue;
+            }
+
+            $useOrderAddressExtensionEnabled =
+                $this->enderecoService->isUseOrderAddressExtensionFeatureEnabled($orderSalesChannelId);
+
+            // Skip the entity if the feature enderecoCopyExtensionIntoOrderAddress is disabled
+            // for its originating sales channel
+            if (!$useOrderAddressExtensionEnabled) {
                 continue;
             }
 


### PR DESCRIPTION
The copying of the CustomerAddressExtension into
the OrderAddressExtension on order finish
provides a new functionality.

Not every user might want this new functionality.
In order to let every user decide for themselves,
this functionality is bound to a new feature toggle in the plugin configuration.

In addition to that, this leaves the option to simply turn off this distinct new feature instead of deactivating the entire plugin, if unforeseen problem should occur.

Ref: DEV-677