### PR TITLE
Downgrade TransportExceptions to Warning-Level

### DIFF
--- a/src/Controller/Storefront/EnderecoApiProxyController.php
+++ b/src/Controller/Storefront/EnderecoApiProxyController.php
@@ -121,7 +121,7 @@ class EnderecoApiProxyController
             );
         } catch (TransportExceptionInterface $e) {
             // Network/timeout errors (connection failed, timeout, DNS issues, etc.)
-            $this->logger->error('Endereco API transport error', [
+            $this->logger->warning('Endereco API transport error', [
                 'error' => $e->getMessage(),
                 'sales_channel_id' => $salesChannelId,
             ]);


### PR DESCRIPTION
Timeouts and connection failures don't necessarily mean that the Endereco services are not available.

To avoid misunderstandings on the customers side,
TransportExceptions, that catch these cases,
should log their messages as Warnings instead
of Errors.

Ref: DEV-725