### PR TITLE
Downgrade serverside ConnectExceptions to Warning-Level

### DIFF
--- a/src/Service/AddressCheck/AddressChecker.php
+++ b/src/Service/AddressCheck/AddressChecker.php
@@ -11,6 +11,7 @@ use Endereco\Shopware6Client\Service\EnderecoService\PayloadPreparatorInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\RequestHeadersGeneratorInterface;
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
@@ -114,6 +115,13 @@ final class AddressChecker implements AddressCheckerInterface
                     $this->logger->error('Serverside checkAddress failed', ['error' => $e->getMessage()]);
                 }
             }
+
+            $addressCheckResult = new FailedAddressCheckResult();
+        } catch (ConnectException $e) {
+            $this->logger->warning(
+                'Serverside checkAddress failed',
+                ['error' => $e->getMessage(), 'sales_channel_id' => $salesChannelId, 'session_id' => $sessionId]
+            );
 
             $addressCheckResult = new FailedAddressCheckResult();
         } catch (Throwable $e) {

--- a/src/Service/AddressCorrection/StreetSplitter.php
+++ b/src/Service/AddressCorrection/StreetSplitter.php
@@ -8,6 +8,7 @@ use Endereco\Shopware6Client\DTO\SplitStreetResultDto;
 use Endereco\Shopware6Client\Service\EnderecoService\PayloadPreparatorInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\RequestHeadersGeneratorInterface;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
@@ -104,6 +105,12 @@ final class StreetSplitter implements StreetSplitterInterface
                     $this->logger->error('Serverside splitStreet failed', ['error' => $e->getMessage()]);
                 }
             }
+        } catch (ConnectException $e) {
+            // Handle and log timeout and transport errors.
+            $this->logger->warning(
+                'Serverside splitStreet failed',
+                ['error' => $e->getMessage(), 'sales_channel_id' => $salesChannelId]
+            );
         } catch (Throwable $e) {
             // Handle and log any other types of errors.
             $this->logger->error('Serverside splitStreet failed', ['error' => $e->getMessage()]);

--- a/src/Service/SessionManagementService.php
+++ b/src/Service/SessionManagementService.php
@@ -7,6 +7,7 @@ namespace Endereco\Shopware6Client\Service;
 use Endereco\Shopware6Client\Service\EnderecoService\PayloadPreparatorInterface;
 use Endereco\Shopware6Client\Service\EnderecoService\RequestHeadersGeneratorInterface;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
@@ -115,6 +116,12 @@ class SessionManagementService
                         $this->logger->error('Serverside doAccounting failed', ['error' => $e->getMessage()]);
                     }
                 }
+            } catch (ConnectException $e) {
+                // Log timeout and transport errors during 'doAccounting'
+                $this->logger->warning(
+                    'Serverside doAccounting failed',
+                    ['error' => $e->getMessage(), 'sales_channel_id' => $salesChannelId, 'session_id' => $sessionId]
+                );
             } catch (Throwable $e) {
                 // Log error message for any other exceptions during 'doAccounting'
                 $this->logger->error('Serverside doAccounting failed', ['error' => $e->getMessage()]);


### PR DESCRIPTION
Timeouts and connection failures don't necessarily mean that the Endereco services are not available.

To avoid misunderstandings on the customers side,
GuzzleHttp's ConnectExceptions, that catch these cases for serverside services, should log their messages as Warnings instead of Errors.

Ref: DEV-726