### PR TITLE
Fix circular reference causing clone recursion crash

### DIFF
--- a/src/Entity/EnderecoAddressExtension/CustomerAddress/EnderecoCustomerAddressExtensionEntity.php
+++ b/src/Entity/EnderecoAddressExtension/CustomerAddress/EnderecoCustomerAddressExtensionEntity.php
@@ -76,6 +76,21 @@ class EnderecoCustomerAddressExtensionEntity extends EnderecoBaseAddressExtensio
     }
 
     /**
+     * Fixes the circular reference to address when cloning.
+     *
+     * CustomerAddressEntity holds this extension in its `extensions` array, and this
+     * extension holds a back-reference to that same CustomerAddressEntity via `$address`.
+     * Shopware's CloneTrait::__clone() deep-clones every object property with no cycle
+     * detection, so cloning either side of this pair recurses infinitely and exhausts the
+     * PHP call stack. Nulling the back-reference on the clone breaks the cycle.
+     */
+    public function __clone()
+    {
+        $this->address = null;
+        parent::__clone();
+    }
+
+    /**
      * Override getUniqueIdentifier to ensure consistent behavior with Shopware's collection system.
      * Uses addressId as a fallback if the the unique identifier wasn't explicitly set.
      * This prevents TypeError when the entity is processed through collections before database hydration,


### PR DESCRIPTION
The enderecoAddress extension held a back-reference to its own parent address, creating a cycle.
Shopware's CloneTrait clones object properties recursively with no cycle detection, so any clone of this pair (e.g. logging out after an address was edited
via Admin or directly in the database, causing the extension to be recreated with a live back-reference) blew the PHP call stack.

Null the back-reference in __clone() before delegating to the parent clone.

Ref: DEV-795